### PR TITLE
avr: correct register for Set() operation on pins 0-7

### DIFF
--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -41,7 +41,7 @@ func (p GPIO) Set(value bool) {
 		}
 	} else { // clear bits
 		if p.Pin < 8 {
-			*avr.PORTB &^= 1 << p.Pin
+			*avr.PORTD &^= 1 << p.Pin
 		} else {
 			*avr.PORTB &^= 1 << (p.Pin - 8)
 		}


### PR DESCRIPTION
The register to be used for operations on AVR pins 0-7 should be `PORTD` not `PORTB`. This PR fixes this to use the correct register, was probably a copy and paste error.