### PR TITLE
Implement GPIO pin Get() function for AVR

### DIFF
--- a/src/examples/button/button.go
+++ b/src/examples/button/button.go
@@ -5,11 +5,15 @@ import (
 	"runtime"
 )
 
+// this example assumes that the button is connected to pin 8. Change the value below
+// to use a different pin.
+const buttonPin = 8
+
 func main() {
 	led := machine.GPIO{machine.LED}
 	led.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
 
-	button := machine.GPIO{8}
+	button := machine.GPIO{buttonPin}
 	button.Configure(machine.GPIOConfig{Mode: machine.GPIO_INPUT})
 
 	for {

--- a/src/examples/button/button.go
+++ b/src/examples/button/button.go
@@ -12,8 +12,6 @@ func main() {
 	button := machine.GPIO{8}
 	button.Configure(machine.GPIOConfig{Mode: machine.GPIO_INPUT})
 
-	led.High()
-
 	for {
 		if button.Get() {
 			led.Low()
@@ -21,6 +19,6 @@ func main() {
 			led.High()
 		}
 
-		runtime.Sleep(runtime.Millisecond * 100)
+		runtime.Sleep(runtime.Millisecond * 10)
 	}
 }

--- a/src/examples/button/button.go
+++ b/src/examples/button/button.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"machine"
+	"runtime"
+)
+
+func main() {
+	led := machine.GPIO{machine.LED}
+	led.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+
+	button := machine.GPIO{8}
+	button.Configure(machine.GPIOConfig{Mode: machine.GPIO_INPUT})
+
+	led.High()
+
+	for {
+		if button.Get() {
+			led.Low()
+		} else {
+			led.High()
+		}
+
+		runtime.Sleep(runtime.Millisecond * 100)
+	}
+}

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -41,7 +41,7 @@ func (p GPIO) Set(value bool) {
 		}
 	} else { // clear bits
 		if p.Pin < 8 {
-			*avr.PORTB &^= 1 << p.Pin
+			*avr.PORTD &^= 1 << p.Pin
 		} else {
 			*avr.PORTB &^= 1 << (p.Pin - 8)
 		}

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -47,3 +47,14 @@ func (p GPIO) Set(value bool) {
 		}
 	}
 }
+
+// Get returns the current value of a GPIO pin.
+func (p GPIO) Get() (value bool) {
+	if p.Pin < 8 {
+		val := *avr.PIND & (1 << p.Pin)
+		return (val > 0)
+	} else {
+		val := *avr.PINB & (1 << (p.Pin - 8))
+		return (val > 0)
+	}
+}

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -49,7 +49,7 @@ func (p GPIO) Set(value bool) {
 }
 
 // Get returns the current value of a GPIO pin.
-func (p GPIO) Get() (value bool) {
+func (p GPIO) Get() bool {
 	if p.Pin < 8 {
 		val := *avr.PIND & (1 << p.Pin)
 		return (val > 0)

--- a/src/machine/machine_dummy.go
+++ b/src/machine/machine_dummy.go
@@ -25,3 +25,7 @@ func (p GPIO) Configure(config GPIOConfig) {
 
 func (p GPIO) Set(value bool) {
 }
+
+func (p GPIO) Get() (value bool) {
+	return
+}

--- a/src/machine/machine_dummy.go
+++ b/src/machine/machine_dummy.go
@@ -26,6 +26,6 @@ func (p GPIO) Configure(config GPIOConfig) {
 func (p GPIO) Set(value bool) {
 }
 
-func (p GPIO) Get() (value bool) {
-	return
+func (p GPIO) Get() bool {
+	return false
 }

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -41,7 +41,7 @@ func (p GPIO) Set(high bool) {
 }
 
 // Get returns the current value of a GPIO pin.
-func (p GPIO) Get() (value bool) {
+func (p GPIO) Get() bool {
 	// TODO: implement
-	return
+	return false
 }

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -39,3 +39,9 @@ func (p GPIO) Set(high bool) {
 		nrf.P0.OUTCLR = 1 << p.Pin
 	}
 }
+
+// Get returns the current value of a GPIO pin.
+func (p GPIO) Get() (value bool) {
+	// TODO: implement
+	return
+}


### PR DESCRIPTION
This PR implements a GPIO pin `Get()` function for AVR. For example:

```go
if button.Get() {
	led.Low()
}
```

It also adds an example program, and placeholder for the NRF machine.