### PR TITLE
avr: initial implementation for PWM

### DIFF
--- a/src/examples/pwm/pwm.go
+++ b/src/examples/pwm/pwm.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"machine"
+	"runtime"
+)
+
+// This example assumes that an RGB LED is connected to pins 3, 5 and 6 on an Arduino.
+// Change the values below to use different pins.
+const (
+	redPin   = 3
+	greenPin = 5
+	bluePin  = 6
+)
+
+// cycleColor is just a placeholder until math/rand or some equivalent is working.
+func cycleColor(color uint8) uint8 {
+
+	if color < 10 {
+		return color + 1
+	}
+	if color > 30 && color < 200 {
+		return color + 10
+	}
+	if color > 230 {
+		return 0
+	}
+	return 0
+}
+
+func main() {
+	machine.InitPWM()
+
+	red := machine.PWM{redPin}
+	red.Configure()
+
+	green := machine.PWM{greenPin}
+	green.Configure()
+
+	blue := machine.PWM{bluePin}
+	blue.Configure()
+
+	var rc uint8
+	var gc uint8 = 20
+	var bc uint8 = 30
+
+	for {
+		rc = cycleColor(rc)
+		gc = cycleColor(gc)
+		bc = cycleColor(bc)
+
+		red.Set(rc)
+		green.Set(gc)
+		blue.Set(bc)
+
+		runtime.Sleep(runtime.Millisecond * 500)
+	}
+}

--- a/src/examples/pwm/pwm.go
+++ b/src/examples/pwm/pwm.go
@@ -14,8 +14,7 @@ const (
 )
 
 // cycleColor is just a placeholder until math/rand or some equivalent is working.
-func cycleColor(color uint8) uint8 {
-
+func cycleColor(color uint16) uint16 {
 	if color < 10 {
 		return color + 1
 	}
@@ -40,9 +39,9 @@ func main() {
 	blue := machine.PWM{bluePin}
 	blue.Configure()
 
-	var rc uint8
-	var gc uint8 = 20
-	var bc uint8 = 30
+	var rc uint16
+	var gc uint16 = 20
+	var bc uint16 = 30
 
 	for {
 		rc = cycleColor(rc)

--- a/src/examples/pwm/pwm.go
+++ b/src/examples/pwm/pwm.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"machine"
-	"runtime"
+	"time"
 )
 
 // This example assumes that an RGB LED is connected to pins 3, 5 and 6 on an Arduino.
@@ -52,6 +52,6 @@ func main() {
 		green.Set(gc)
 		blue.Set(bc)
 
-		runtime.Sleep(runtime.Millisecond * 500)
+		time.Sleep(time.Millisecond * 500)
 	}
 }

--- a/src/machine/machine.go
+++ b/src/machine/machine.go
@@ -15,3 +15,7 @@ func (p GPIO) High() {
 func (p GPIO) Low() {
 	p.Set(false)
 }
+
+type PWM struct {
+	Pin uint8
+}

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -58,3 +58,93 @@ func (p GPIO) Get() bool {
 		return (val > 0)
 	}
 }
+
+const (
+	COM2A1 = 7
+	COM2A0 = 6
+	COM2B1 = 5
+	COM2B0 = 4
+	COM0A1 = 7
+	COM0A0 = 6
+	COM0B1 = 5
+	COM0B0 = 4
+	COM1A1 = 7
+	COM1A0 = 6
+	COM1B1 = 5
+	COM1B0 = 4
+
+	CS00 = 0
+	CS01 = 1
+	CS11 = 1
+	CS22 = 2
+
+	WGM10 = 0
+	WGM11 = 1
+	WGM20 = 0
+	WGM21 = 1
+)
+
+// InitPWM initializes the registers needed for PWM.
+func InitPWM() {
+	// use waveform generation
+	*avr.TCCR0A |= avr.TCCR0A_WGM0
+
+	// set timer 0 prescale factor to 64
+	*avr.TCCR0B |= 1 << CS01
+	*avr.TCCR0B |= 1 << CS00
+
+	// set timer 1 prescale factor to 64
+	*avr.TCCR1B |= 1 << CS11
+
+	// put timer 1 in 8-bit phase correct pwm mode
+	*avr.TCCR1A |= 1 << WGM10
+
+	// set timer 2 prescale factor to 64
+	*avr.TCCR2B |= 1 << CS22
+
+	// configure timer 2 for phase correct pwm (8-bit)
+	*avr.TCCR2A |= 1 << WGM20
+}
+
+// Configure configures a PWM pin for output.
+func (pwm PWM) Configure() {
+	if pwm.Pin < 8 {
+		*avr.DDRD |= 1 << pwm.Pin
+	} else {
+		*avr.DDRB |= 1 << (pwm.Pin - 8)
+	}
+}
+
+// Set sets the needed register values to turn on the duty cycle for a PWM pin.
+func (pwm PWM) Set(value uint8) {
+	switch pwm.Pin {
+	case 3:
+		// connect pwm to pin on timer 2, channel B
+		*avr.TCCR2A |= 1 << COM2B1
+		*avr.OCR2B = avr.RegValue(value) // set pwm duty
+	case 5:
+		// connect pwm to pin on timer 0, channel B
+		*avr.TCCR0A |= 1 << COM0B1
+		*avr.OCR0B = avr.RegValue(value) // set pwm duty
+	case 6:
+		// connect pwm to pin on timer 0, channel A
+		*avr.TCCR0A |= 1 << COM0A1
+		*avr.OCR0A = avr.RegValue(value) // set pwm duty
+	case 9:
+		// connect pwm to pin on timer 1, channel A
+		*avr.TCCR1A |= 1 << COM1A1
+		// this is a 16-bit value, but we only currently allow the low order bits to be set
+		*avr.OCR1AL = avr.RegValue(value) // set pwm duty
+	case 10:
+		// connect pwm to pin on timer 1, channel B
+		*avr.TCCR1A |= 1 << COM1B1
+		// this is a 16-bit value, but we only currently allow the low order bits to be set
+		*avr.OCR1BL = avr.RegValue(value) // set pwm duty
+	case 11:
+		// connect pwm to pin on timer 2, channel A
+		*avr.TCCR2A |= 1 << COM2A1
+		*avr.OCR2A = avr.RegValue(value) // set pwm duty
+	default:
+		// TODO: handle invalid pin for PWM on Arduino
+	}
+}

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -59,51 +59,25 @@ func (p GPIO) Get() bool {
 	}
 }
 
-const (
-	COM2A1 = 7
-	COM2A0 = 6
-	COM2B1 = 5
-	COM2B0 = 4
-	COM0A1 = 7
-	COM0A0 = 6
-	COM0B1 = 5
-	COM0B0 = 4
-	COM1A1 = 7
-	COM1A0 = 6
-	COM1B1 = 5
-	COM1B0 = 4
-
-	CS00 = 0
-	CS01 = 1
-	CS11 = 1
-	CS22 = 2
-
-	WGM10 = 0
-	WGM11 = 1
-	WGM20 = 0
-	WGM21 = 1
-)
-
 // InitPWM initializes the registers needed for PWM.
 func InitPWM() {
 	// use waveform generation
-	*avr.TCCR0A |= avr.TCCR0A_WGM0
+	*avr.TCCR0A |= avr.TCCR0A_WGM00
 
 	// set timer 0 prescale factor to 64
-	*avr.TCCR0B |= 1 << CS01
-	*avr.TCCR0B |= 1 << CS00
+	*avr.TCCR0B |= avr.TCCR0B_CS01 | avr.TCCR0B_CS00
 
 	// set timer 1 prescale factor to 64
-	*avr.TCCR1B |= 1 << CS11
+	*avr.TCCR1B |= avr.TCCR1B_CS11
 
 	// put timer 1 in 8-bit phase correct pwm mode
-	*avr.TCCR1A |= 1 << WGM10
+	*avr.TCCR1A |= avr.TCCR1A_WGM10
 
 	// set timer 2 prescale factor to 64
-	*avr.TCCR2B |= 1 << CS22
+	*avr.TCCR2B |= avr.TCCR2B_CS22
 
 	// configure timer 2 for phase correct pwm (8-bit)
-	*avr.TCCR2A |= 1 << WGM20
+	*avr.TCCR2A |= avr.TCCR2A_WGM20
 }
 
 // Configure configures a PWM pin for output.
@@ -115,36 +89,37 @@ func (pwm PWM) Configure() {
 	}
 }
 
-// Set sets the needed register values to turn on the duty cycle for a PWM pin.
-func (pwm PWM) Set(value uint8) {
+// Set turns on the duty cycle for a PWM pin using the provided value. On the AVR this is normally a
+// 8-bit value ranging from 0 to 255.
+func (pwm PWM) Set(value uint16) {
 	switch pwm.Pin {
 	case 3:
 		// connect pwm to pin on timer 2, channel B
-		*avr.TCCR2A |= 1 << COM2B1
-		*avr.OCR2B = avr.RegValue(value) // set pwm duty
+		*avr.TCCR2A |= avr.TCCR2A_COM2B1
+		*avr.OCR2B = avr.RegValue(uint8(value)) // set pwm duty
 	case 5:
 		// connect pwm to pin on timer 0, channel B
-		*avr.TCCR0A |= 1 << COM0B1
-		*avr.OCR0B = avr.RegValue(value) // set pwm duty
+		*avr.TCCR0A |= avr.TCCR0A_COM0B1
+		*avr.OCR0B = avr.RegValue(uint8(value)) // set pwm duty
 	case 6:
 		// connect pwm to pin on timer 0, channel A
-		*avr.TCCR0A |= 1 << COM0A1
-		*avr.OCR0A = avr.RegValue(value) // set pwm duty
+		*avr.TCCR0A |= avr.TCCR0A_COM0A1
+		*avr.OCR0A = avr.RegValue(uint8(value)) // set pwm duty
 	case 9:
 		// connect pwm to pin on timer 1, channel A
-		*avr.TCCR1A |= 1 << COM1A1
+		*avr.TCCR1A |= avr.TCCR1A_COM1A1
 		// this is a 16-bit value, but we only currently allow the low order bits to be set
-		*avr.OCR1AL = avr.RegValue(value) // set pwm duty
+		*avr.OCR1AL = avr.RegValue(uint8(value)) // set pwm duty
 	case 10:
 		// connect pwm to pin on timer 1, channel B
-		*avr.TCCR1A |= 1 << COM1B1
+		*avr.TCCR1A |= avr.TCCR1A_COM1B1
 		// this is a 16-bit value, but we only currently allow the low order bits to be set
-		*avr.OCR1BL = avr.RegValue(value) // set pwm duty
+		*avr.OCR1BL = avr.RegValue(uint8(value)) // set pwm duty
 	case 11:
 		// connect pwm to pin on timer 2, channel A
-		*avr.TCCR2A |= 1 << COM2A1
-		*avr.OCR2A = avr.RegValue(value) // set pwm duty
+		*avr.TCCR2A |= avr.TCCR2A_COM2A1
+		*avr.OCR2A = avr.RegValue(uint8(value)) // set pwm duty
 	default:
-		// TODO: handle invalid pin for PWM on Arduino
+		panic("Invalid PWM pin")
 	}
 }

--- a/src/runtime/runtime_avr.go
+++ b/src/runtime/runtime_avr.go
@@ -56,12 +56,12 @@ func initUART() {
 	// Initialize UART at 115200 baud when running at 16MHz.
 	*avr.UBRR0H = 0
 	*avr.UBRR0L = 8
-	*avr.UCSR0B = avr.UCSR0B_RXEN0 | avr.UCSR0B_TXEN0 // enable RX and TX
-	*avr.UCSR0C = avr.UCSR0C_UCSZ0                    // 8-bits data
+	*avr.UCSR0B = avr.UCSR0B_RXEN00 | avr.UCSR0B_TXEN00 // enable RX and TX
+	*avr.UCSR0C = avr.UCSR0C_UCSZ00                     // 8-bits data
 }
 
 func putchar(c byte) {
-	for (*avr.UCSR0A & avr.UCSR0A_UDRE0) == 0 {
+	for (*avr.UCSR0A & avr.UCSR0A_UDRE00) == 0 {
 		// Wait until previous char has been sent.
 	}
 	*avr.UDR0 = avr.RegValue(c) // send char
@@ -95,15 +95,15 @@ func sleepWDT(period uint8) {
 	avr.Asm("cli")
 	avr.Asm("wdr")
 	// Start timed sequence.
-	*avr.WDTCSR |= avr.WDTCSR_WDCE | avr.WDTCSR_WDE
+	*avr.WDTCSR |= avr.WDTCSR_WDCE0 | avr.WDTCSR_WDE0
 	// Enable WDT and set new timeout (0.5s)
-	*avr.WDTCSR = avr.WDTCSR_WDIE | avr.RegValue(period)
+	*avr.WDTCSR = avr.WDTCSR_WDIE0 | avr.RegValue(period)
 	avr.Asm("sei")
 
 	// Set sleep mode to idle and enable sleep mode.
 	// Note: when using something other than idle, the UART won't work
 	// correctly. This needs to be fixed, though, so we can truly sleep.
-	*avr.SMCR = (0 << 1) | avr.SMCR_SE
+	*avr.SMCR = (0 << 1) | avr.SMCR_SE0
 
 	// go to sleep
 	avr.Asm("sleep")

--- a/src/runtime/runtime_avr.go
+++ b/src/runtime/runtime_avr.go
@@ -56,12 +56,12 @@ func initUART() {
 	// Initialize UART at 115200 baud when running at 16MHz.
 	*avr.UBRR0H = 0
 	*avr.UBRR0L = 8
-	*avr.UCSR0B = avr.UCSR0B_RXEN00 | avr.UCSR0B_TXEN00 // enable RX and TX
-	*avr.UCSR0C = avr.UCSR0C_UCSZ00                     // 8-bits data
+	*avr.UCSR0B = avr.UCSR0B_RXEN0 | avr.UCSR0B_TXEN0 // enable RX and TX
+	*avr.UCSR0C = avr.UCSR0C_UCSZ00                   // 8-bits data
 }
 
 func putchar(c byte) {
-	for (*avr.UCSR0A & avr.UCSR0A_UDRE00) == 0 {
+	for (*avr.UCSR0A & avr.UCSR0A_UDRE0) == 0 {
 		// Wait until previous char has been sent.
 	}
 	*avr.UDR0 = avr.RegValue(c) // send char
@@ -95,15 +95,15 @@ func sleepWDT(period uint8) {
 	avr.Asm("cli")
 	avr.Asm("wdr")
 	// Start timed sequence.
-	*avr.WDTCSR |= avr.WDTCSR_WDCE0 | avr.WDTCSR_WDE0
+	*avr.WDTCSR |= avr.WDTCSR_WDCE | avr.WDTCSR_WDE
 	// Enable WDT and set new timeout (0.5s)
-	*avr.WDTCSR = avr.WDTCSR_WDIE0 | avr.RegValue(period)
+	*avr.WDTCSR = avr.WDTCSR_WDIE | avr.RegValue(period)
 	avr.Asm("sei")
 
 	// Set sleep mode to idle and enable sleep mode.
 	// Note: when using something other than idle, the UART won't work
 	// correctly. This needs to be fixed, though, so we can truly sleep.
-	*avr.SMCR = (0 << 1) | avr.SMCR_SE0
+	*avr.SMCR = (0 << 1) | avr.SMCR_SE
 
 	// go to sleep
 	avr.Asm("sleep")

--- a/src/runtime/runtime_avr.go
+++ b/src/runtime/runtime_avr.go
@@ -56,8 +56,8 @@ func initUART() {
 	// Initialize UART at 115200 baud when running at 16MHz.
 	*avr.UBRR0H = 0
 	*avr.UBRR0L = 8
-	*avr.UCSR0B = avr.UCSR0B_RXEN0 | avr.UCSR0B_TXEN0 // enable RX and TX
-	*avr.UCSR0C = avr.UCSR0C_UCSZ00                   // 8-bits data
+	*avr.UCSR0B = avr.UCSR0B_RXEN0 | avr.UCSR0B_TXEN0   // enable RX and TX
+	*avr.UCSR0C = avr.UCSR0C_UCSZ01 | avr.UCSR0C_UCSZ00 // 8-bits data
 }
 
 func putchar(c byte) {

--- a/tools/gen-device-avr.py
+++ b/tools/gen-device-avr.py
@@ -24,6 +24,13 @@ def formatText(text):
     text = text.strip()
     return text
 
+def getShift(bitmask):
+    count = 0
+    while not(bitmask & 0x1):
+        bitmask >>= 1
+        count+=1
+    return count
+
 def readATDF(path):
     # Read Atmel device descriptor files.
     # See: http://packs.download.atmel.com
@@ -183,10 +190,15 @@ const (
                     out.write(': {description}'.format(**register))
                 out.write('\n')
             for bitfield in register['bitfields']:
-                out.write('\t{name} = 0x{value:x}'.format(**bitfield))
-                if bitfield['description']:
-                    out.write(' // {description}'.format(**bitfield))
-                out.write('\n')
+                name = bitfield['name']
+                value = bitfield['value']
+                bitshift = getShift(value)
+                for c in range(bin(value >> bitshift).count("1")):
+                    v = hex(1 << (bitshift + c))
+                    out.write('\t{0}{1} = {2}'.format(name, c, v))
+                    if bitfield['description']:
+                        out.write(' // {description}'.format(**bitfield))
+                    out.write('\n')
         out.write(')\n')
 
 def writeLD(outdir, device):


### PR DESCRIPTION
This is a initial implementation of PWM for the AVR on the Arduino Uno. It mimics the pattern established by `GPIO` but with appropriate changes for the setting of PWM on pins that support it.

There is also an included example program, that has been tested on an Arduino Uno with an RGB LED connected.