### PR TITLE
Add nrf example for all 4 built-in buttons and LEDs

### DIFF
--- a/src/examples/button2/button2.go
+++ b/src/examples/button2/button2.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"machine"
+	"time"
+)
+
+// This example assumes that you are using the pca10040 board
+
+func setLED(led *machine.GPIO, state bool) {
+	if state {
+		led.High()
+	} else {
+		led.Low()
+	}
+}
+
+func main() {
+	led1 := machine.GPIO{machine.LED1}
+	led1.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+
+	led2 := machine.GPIO{machine.LED2}
+	led2.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+
+	led3 := machine.GPIO{machine.LED3}
+	led3.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+
+	led4 := machine.GPIO{machine.LED4}
+	led4.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+
+	button1 := machine.GPIO{machine.BUTTON1}
+	button1.Configure(machine.GPIOConfig{Mode: machine.GPIO_INPUT_PULLUP})
+
+	button2 := machine.GPIO{machine.BUTTON2}
+	button2.Configure(machine.GPIOConfig{Mode: machine.GPIO_INPUT_PULLUP})
+
+	button3 := machine.GPIO{machine.BUTTON3}
+	button3.Configure(machine.GPIOConfig{Mode: machine.GPIO_INPUT_PULLUP})
+
+	button4 := machine.GPIO{machine.BUTTON4}
+	button4.Configure(machine.GPIOConfig{Mode: machine.GPIO_INPUT_PULLUP})
+
+	for {
+		setLED(&led1, button1.Get())
+		setLED(&led2, button2.Get())
+		setLED(&led3, button3.Get())
+		setLED(&led4, button4.Get())
+
+		time.Sleep(time.Millisecond * 10)
+	}
+}


### PR DESCRIPTION
This PR adds an example for the PCA10040 that exercises all four built-in buttons and LEDs.