### PR TITLE
avr: implement UART interface

### DIFF
--- a/src/examples/echo/echo.go
+++ b/src/examples/echo/echo.go
@@ -1,5 +1,5 @@
 // This is a echo console running on the device UART.
-// Connect using 57600 baud, 8-N-1 with your terminal program.
+// Connect using default baudrate for this hardware, 8-N-1 with your terminal program.
 package main
 
 import (
@@ -8,8 +8,7 @@ import (
 )
 
 func main() {
-	// Set baudrate to 56k for an Arduino Uno to be error-free.
-	machine.UART0.Configure(machine.UARTConfig{Baudrate: 57600})
+	machine.UART0.Configure(machine.UARTConfig{})
 	machine.UART0.Write([]byte("Echo console enabled. Type something then press enter:\r\n"))
 
 	input := make([]byte, 64)

--- a/src/examples/echo/echo.go
+++ b/src/examples/echo/echo.go
@@ -17,9 +17,6 @@ func main() {
 		if machine.UART0.Buffered() > 0 {
 			data, _ := machine.UART0.ReadByte()
 
-			// Remove high-order bit because 7-bit ascii
-			data &^= 0x80
-
 			switch data {
 			case 13:
 				// return key

--- a/src/examples/echo/echo.go
+++ b/src/examples/echo/echo.go
@@ -15,16 +15,15 @@ func main() {
 	input := make([]byte, 64)
 	i := 0
 	for {
-		data, err := machine.UART0.ReadByte()
-		if err != nil {
-			machine.UART0.Write([]byte("input error!\r\n"))
-		} else {
+		if machine.UART0.Buffered() > 0 {
+			data, _ := machine.UART0.ReadByte()
+			// if err == nil {
 			// Remove high-order bit because 7-bit ascii
 			data &^= 0x80
 
 			switch data {
-			case 0:
-				break
+			// case 0:
+			// 	break
 			case 13:
 				// return key
 				machine.UART0.Write([]byte("\r\n"))

--- a/src/examples/echo/echo.go
+++ b/src/examples/echo/echo.go
@@ -17,13 +17,11 @@ func main() {
 	for {
 		if machine.UART0.Buffered() > 0 {
 			data, _ := machine.UART0.ReadByte()
-			// if err == nil {
+
 			// Remove high-order bit because 7-bit ascii
 			data &^= 0x80
 
 			switch data {
-			// case 0:
-			// 	break
 			case 13:
 				// return key
 				machine.UART0.Write([]byte("\r\n"))

--- a/src/examples/echo/echo.go
+++ b/src/examples/echo/echo.go
@@ -1,4 +1,4 @@
-// This is a mini-console running on the device UART.
+// This is a echo console running on the device UART.
 // Connect using 57600 baud, 8-N-1 with your terminal program.
 package main
 
@@ -10,7 +10,7 @@ import (
 func main() {
 	// Set baudrate to 56k for an Arduino Uno to be error-free.
 	machine.UART0.Configure(machine.UARTConfig{Baudrate: 57600})
-	machine.UART0.Write([]byte("UART console enabled...\r\n"))
+	machine.UART0.Write([]byte("Echo console enabled. Type something then press enter:\r\n"))
 
 	input := make([]byte, 64)
 	i := 0
@@ -29,11 +29,8 @@ func main() {
 				// return key
 				machine.UART0.Write([]byte("\r\n"))
 				machine.UART0.Write([]byte("You typed: "))
-				machine.UART0.Write(input)
+				machine.UART0.Write(input[:i])
 				machine.UART0.Write([]byte("\r\n"))
-				for j := 0; j < len(input); j++ {
-					input[j] = 0
-				}
 				i = 0
 			default:
 				// just echo the character

--- a/src/examples/uart/uart.go
+++ b/src/examples/uart/uart.go
@@ -1,3 +1,5 @@
+// This is a mini-console running on the device UART.
+// Connect using 57600 baud, 8-N-1 with your terminal program.
 package main
 
 import (
@@ -6,25 +8,40 @@ import (
 )
 
 func main() {
-	machine.UART0.Configure(machine.UARTConfig{})
-	machine.UART0.Write([]byte("UART echo enabled...\r\n"))
+	// Set baudrate to 56k for an Arduino Uno to be error-free.
+	machine.UART0.Configure(machine.UARTConfig{Baudrate: 57600})
+	machine.UART0.Write([]byte("UART console enabled...\r\n"))
 
+	input := make([]byte, 64)
+	i := 0
 	for {
-		input := make([]byte, 10)
-		n, err := machine.UART0.Read(input)
+		data, err := machine.UART0.ReadByte()
 		if err != nil {
 			machine.UART0.Write([]byte("input error!\r\n"))
 		} else {
-			if n > 0 {
-				machine.UART0.Write([]byte("You typed:\r\n"))
-				for _, v := range input {
-					// Remove high-order bit because 7-bit ascii
-					machine.UART0.WriteByte(v &^ (1 << 7))
-				}
+			// Remove high-order bit because 7-bit ascii
+			data &^= 0x80
 
+			switch data {
+			case 0:
+				break
+			case 13:
+				// return key
 				machine.UART0.Write([]byte("\r\n"))
+				machine.UART0.Write([]byte("You typed: "))
+				machine.UART0.Write(input)
+				machine.UART0.Write([]byte("\r\n"))
+				for j := 0; j < len(input); j++ {
+					input[j] = 0
+				}
+				i = 0
+			default:
+				// just echo the character
+				machine.UART0.WriteByte(data)
+				input[i] = data
+				i++
 			}
 		}
-		time.Sleep(time.Second)
+		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/src/examples/uart/uart.go
+++ b/src/examples/uart/uart.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"machine"
+	"time"
+)
+
+func main() {
+	machine.UART0.Configure(machine.UARTConfig{})
+	machine.UART0.Write([]byte("UART echo enabled...\r\n"))
+
+	for {
+		input := make([]byte, 10)
+		n, err := machine.UART0.Read(input)
+		if err != nil {
+			machine.UART0.Write([]byte("input error!\r\n"))
+		} else {
+			if n > 0 {
+				machine.UART0.Write([]byte("You typed:\r\n"))
+				for _, v := range input {
+					// Remove high-order bit because 7-bit ascii
+					machine.UART0.WriteByte(v &^ (1 << 7))
+				}
+
+				machine.UART0.Write([]byte("\r\n"))
+			}
+		}
+		time.Sleep(time.Second)
+	}
+}

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -312,6 +312,11 @@ func (uart UART) Read(data []byte) (n int, err error) {
 		return 0, nil
 	}
 
+	// Make sure we do not read more from buffer than the data slice can hold.
+	if len(data) < size {
+		size = len(data)
+	}
+
 	// only read number of bytes used from buffer
 	for i := 0; i < size; i++ {
 		v, _ := uart.ReadByte()

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -294,9 +294,10 @@ func (uart UART) Configure(config UARTConfig) {
 		config.Baudrate = 115200
 	}
 
-	// Set baud rate based on prescale formula:
-	// BAUD_PRESCALE = (((F_CPU / (BAUDRATE * 16UL))) - 1)
-	ps := (CPU_FREQUENCY / (config.Baudrate * 16)) - 1
+	// Set baud rate based on prescale formula from
+	// https://www.microchip.com/webdoc/AVRLibcReferenceManual/FAQ_1faq_wrong_baud_rate.html
+	// ((F_CPU + UART_BAUD_RATE * 8L) / (UART_BAUD_RATE * 16L) - 1)
+	ps := ((CPU_FREQUENCY+config.Baudrate*8)/(config.Baudrate*16) - 1)
 	*avr.UBRR0H = avr.RegValue(ps >> 8)
 	*avr.UBRR0L = avr.RegValue(ps)
 

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -4,7 +4,6 @@ package machine
 
 import (
 	"device/avr"
-	"errors"
 )
 
 type GPIOMode uint8
@@ -311,18 +310,14 @@ func (uart UART) Close() error {
 
 // Read from the RX buffer.
 func (uart UART) Read(data []byte) (n int, err error) {
-	if len(data) > bufferSize {
-		return 0, errors.New("Read buffer cannot be larger than RX Buffer")
-	}
-
 	// check if RX buffer is empty
-	size := uart.BufferUsed()
+	size := uart.Buffered()
 	if size == 0 {
 		return 0, nil
 	}
 
 	// only read number of bytes used from buffer
-	for i := 0; uint8(i) < size; i++ {
+	for i := 0; i < size; i++ {
 		data[i] = byte(bufferGet())
 	}
 
@@ -361,8 +356,8 @@ var rxbuffer [bufferSize]__volatile
 var head __volatile
 var tail __volatile
 
-func (uart UART) BufferUsed() uint8 {
-	return bufferUsed()
+func (uart UART) Buffered() int {
+	return int(bufferUsed())
 }
 
 func bufferUsed() uint8 { return uint8(head - tail) }

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -304,11 +304,6 @@ func (uart UART) Configure(config UARTConfig) {
 	*avr.UCSR0B |= avr.UCSR0B_RXCIE0
 }
 
-// Close the UART on the AVR.
-func (uart UART) Close() error {
-	return nil
-}
-
 // Read from the RX buffer.
 func (uart UART) Read(data []byte) (n int, err error) {
 	// check if RX buffer is empty
@@ -320,10 +315,10 @@ func (uart UART) Read(data []byte) (n int, err error) {
 	// only read number of bytes used from buffer
 	for i := 0; i < size; i++ {
 		v, _ := uart.ReadByte()
-		data[i] = byte(v)
+		data[i] = v
 	}
 
-	return len(data), nil
+	return size, nil
 }
 
 // Write data to the UART.
@@ -372,10 +367,10 @@ var head volatileByte
 var tail volatileByte
 
 func bufferUsed() uint8 { return uint8(head - tail) }
-func bufferPut(val volatileByte) {
+func bufferPut(val byte) {
 	if bufferUsed() != bufferSize {
 		head++
-		rxbuffer[head%bufferSize] = val
+		rxbuffer[head%bufferSize] = volatileByte(val)
 	}
 }
 func bufferGet() byte {
@@ -394,6 +389,6 @@ func handleUSART_RX() {
 	// Ensure no error.
 	if (*avr.UCSR0A & (avr.UCSR0A_FE0 | avr.UCSR0A_DOR0 | avr.UCSR0A_UPE0)) == 0 {
 		// Put data from UDR register into buffer.
-		bufferPut(volatileByte(data))
+		bufferPut(byte(data))
 	}
 }

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -387,12 +387,12 @@ func bufferGet() byte {
 
 //go:interrupt USART_RX_vect
 func handleUSART_RX() {
-	// Wait until UART data buffer is ready.
-	for (*avr.UCSR0A & avr.UCSR0A_UDRE0) == 0 {
-	}
+	// Read register to clear it.
+	data := *avr.UDR0
 
+	// Ensure no error.
 	if (*avr.UCSR0A & (avr.UCSR0A_FE0 | avr.UCSR0A_DOR0 | avr.UCSR0A_UPE0)) == 0 {
 		// Read data from UDR register.
-		bufferPut(volatileByte(*avr.UDR0))
+		bufferPut(volatileByte(data))
 	}
 }

--- a/src/runtime/runtime_avr.go
+++ b/src/runtime/runtime_avr.go
@@ -54,9 +54,10 @@ func init() {
 }
 
 func initUART() {
-	// Initialize UART at 115200 baud when running at 16MHz.
+	// Initialize UART at 9600 baud when running at 16MHz.
 	*avr.UBRR0H = 0
-	*avr.UBRR0L = 8
+	*avr.UBRR0L = 0x67
+
 	*avr.UCSR0B = avr.UCSR0B_RXEN0 | avr.UCSR0B_TXEN0   // enable RX and TX
 	*avr.UCSR0C = avr.UCSR0C_UCSZ01 | avr.UCSR0C_UCSZ00 // 8-bits data
 }


### PR DESCRIPTION
This PR implements the UART interface for AVR as defined in the MachineAPI wiki page, including the `io.ReaderWriterCloser` interface.

It also includes a small sample that exercises both transmit and receive.