### PR TITLE
all: use LLVM library provided by the system

### DIFF
--- a/compiler/calls.go
+++ b/compiler/calls.go
@@ -1,7 +1,7 @@
 package compiler
 
 import (
-	"github.com/aykevl/llvm/bindings/go/llvm"
+	"github.com/aykevl/go-llvm"
 	"golang.org/x/tools/go/ssa"
 )
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aykevl/llvm/bindings/go/llvm"
+	"github.com/aykevl/go-llvm"
 	"github.com/aykevl/tinygo/ir"
 	"go/parser"
 	"golang.org/x/tools/go/loader"

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/aykevl/llvm/bindings/go/llvm"
+	"github.com/aykevl/go-llvm"
 	"golang.org/x/tools/go/loader"
 	"golang.org/x/tools/go/ssa"
 	"golang.org/x/tools/go/ssa/ssautil"

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/aykevl/llvm/bindings/go/llvm"
+	"github.com/aykevl/go-llvm"
 	"github.com/aykevl/tinygo/compiler"
 )
 


### PR DESCRIPTION
@deadprogram can you test whether this branch works for you? I hope to merge this soon, to make installation easier in most cases and to enable automatic testing.

Note that most releases do not contain experimental backends like AVR, so that will continue to require a custom build. I haven't yet decided how that should be done exactly, it would be great to simply do `make build` or something like that.

EDIT: it appears like LLVM from apt.llvm.org includes the AVR backend! :D