### PR TITLE
Let the runtime use machine.UART0

### DIFF
--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -291,8 +291,11 @@ func (uart UART) Configure(config UARTConfig) {
 	*avr.UBRR0H = avr.RegValue(ps >> 8)
 	*avr.UBRR0L = avr.RegValue(ps & 0xff)
 
-	// enable RX interrupt
-	*avr.UCSR0B |= avr.UCSR0B_RXCIE0
+	// enable RX, TX and RX interrupt
+	*avr.UCSR0B = avr.UCSR0B_RXEN0 | avr.UCSR0B_TXEN0 | avr.UCSR0B_RXCIE0
+
+	// 8-bits data
+	*avr.UCSR0C = avr.UCSR0C_UCSZ01 | avr.UCSR0C_UCSZ00
 }
 
 // WriteByte writes a byte of data to the UART.

--- a/src/runtime/runtime_avr.go
+++ b/src/runtime/runtime_avr.go
@@ -4,6 +4,7 @@ package runtime
 
 import (
 	"device/avr"
+	"machine"
 	"unsafe"
 )
 
@@ -54,19 +55,11 @@ func init() {
 }
 
 func initUART() {
-	// Initialize UART at 9600 baud when running at 16MHz.
-	*avr.UBRR0H = 0
-	*avr.UBRR0L = 0x67
-
-	*avr.UCSR0B = avr.UCSR0B_RXEN0 | avr.UCSR0B_TXEN0   // enable RX and TX
-	*avr.UCSR0C = avr.UCSR0C_UCSZ01 | avr.UCSR0C_UCSZ00 // 8-bits data
+	machine.UART0.Configure(machine.UARTConfig{})
 }
 
 func putchar(c byte) {
-	for (*avr.UCSR0A & avr.UCSR0A_UDRE0) == 0 {
-		// Wait until previous char has been sent.
-	}
-	*avr.UDR0 = avr.RegValue(c) // send char
+	machine.UART0.WriteByte(c)
 }
 
 // Sleep this number of ticks of 16ms.

--- a/src/runtime/runtime_nrf.go
+++ b/src/runtime/runtime_nrf.go
@@ -5,6 +5,7 @@ package runtime
 import (
 	"device/arm"
 	"device/nrf"
+	"machine"
 )
 
 type timeUnit int64
@@ -21,17 +22,9 @@ func handleReset() {
 }
 
 func init() {
-	initUART()
+	machine.UART0.Configure(machine.UARTConfig{})
 	initLFCLK()
 	initRTC()
-}
-
-func initUART() {
-	nrf.UART0.ENABLE = nrf.UART_ENABLE_ENABLE_Enabled
-	nrf.UART0.BAUDRATE = nrf.UART_BAUDRATE_BAUDRATE_Baud115200
-	nrf.UART0.TASKS_STARTTX = 1
-	nrf.UART0.PSELTXD = 6 // pin 6 for NRF52840-DK
-	nrf.UART0.PSELRXD = 8 // pin 8 for NRF52840-DK
 }
 
 func initLFCLK() {
@@ -49,10 +42,7 @@ func initRTC() {
 }
 
 func putchar(c byte) {
-	nrf.UART0.TXD = nrf.RegValue(c)
-	for nrf.UART0.EVENTS_TXDRDY == 0 {
-	}
-	nrf.UART0.EVENTS_TXDRDY = 0
+	machine.UART0.WriteByte(c)
 }
 
 func sleepTicks(d timeUnit) {


### PR DESCRIPTION
Remove lots of board-specific configuration from the runtime.

Consequences:

 * New boards are much easier to support, with less hacks. This will make #27 and #30 easier.
 * The machine package won't be able to import the runtime package because circular dependencies are not allowed in Go. However, there are ways to hack around this (even the Go standard library does that).
 * Code size is increased for very small programs that don't use the machine package (for example, examples/serial). I think this is because of the interrupts. However, most bigger programs will be using the machine package anyway so there is no real cost in practice.
 * Code size is roughly the same (+2 for AVR) or even reduced (-32 for NRF) for programs that do use the machine module, like examples/echo.

All in all, I think this is the way forward.