### PR TITLE
NRF: Implement i2c interface

### DIFF
--- a/src/examples/blinkm/blinkm.go
+++ b/src/examples/blinkm/blinkm.go
@@ -23,15 +23,15 @@ func main() {
 		switch count {
 		case 0:
 			// Crimson
-			machine.I2C0.WriteTo(0x09, []byte{byte('n'), 0xdc, 0x14, 0x3c})
+			machine.I2C0.WriteTo(0x09, []byte{'n', 0xdc, 0x14, 0x3c})
 			count = 1
 		case 1:
 			// MediumPurple
-			machine.I2C0.WriteTo(0x09, []byte{byte('n'), 0x93, 0x70, 0xdb})
+			machine.I2C0.WriteTo(0x09, []byte{'n', 0x93, 0x70, 0xdb})
 			count = 2
 		case 2:
 			// MediumSeaGreen
-			machine.I2C0.WriteTo(0x09, []byte{byte('n'), 0x3c, 0xb3, 0x71})
+			machine.I2C0.WriteTo(0x09, []byte{'n', 0x3c, 0xb3, 0x71})
 			count = 0
 		}
 

--- a/src/examples/blinkm/blinkm.go
+++ b/src/examples/blinkm/blinkm.go
@@ -20,20 +20,18 @@ func main() {
 
 	count := 0
 	for {
-		machine.I2C0.WriteTo(0x09, []byte("n"))
-
 		switch count {
 		case 0:
 			// Crimson
-			machine.I2C0.WriteTo(0x09, []byte{0xdc, 0x14, 0x3c})
+			machine.I2C0.WriteTo(0x09, []byte{byte('n'), 0xdc, 0x14, 0x3c})
 			count = 1
 		case 1:
 			// MediumPurple
-			machine.I2C0.WriteTo(0x09, []byte{0x93, 0x70, 0xdb})
+			machine.I2C0.WriteTo(0x09, []byte{byte('n'), 0x93, 0x70, 0xdb})
 			count = 2
 		case 2:
 			// MediumSeaGreen
-			machine.I2C0.WriteTo(0x09, []byte{0x3c, 0xb3, 0x71})
+			machine.I2C0.WriteTo(0x09, []byte{byte('n'), 0x3c, 0xb3, 0x71})
 			count = 0
 		}
 

--- a/src/machine/board_pca10040.go
+++ b/src/machine/board_pca10040.go
@@ -35,3 +35,9 @@ const (
 	ADC4 = 30
 	ADC5 = 31
 )
+
+// I2C pins
+const (
+	SDA_PIN = 26
+	SCL_PIN = 27
+)

--- a/src/machine/board_pca10040.go
+++ b/src/machine/board_pca10040.go
@@ -28,10 +28,10 @@ const (
 
 // ADC pins
 const (
-	ADCPin0 = 3
-	ADCPin1 = 4
-	ADCPin2 = 28
-	ADCPin3 = 29
-	ADCPin4 = 30
-	ADCPin5 = 31
+	ADC0 = 3
+	ADC1 = 4
+	ADC2 = 28
+	ADC3 = 29
+	ADC4 = 30
+	ADC5 = 31
 )

--- a/src/machine/board_pca10040.go
+++ b/src/machine/board_pca10040.go
@@ -25,3 +25,13 @@ const (
 	UART_TX_PIN = 6
 	UART_RX_PIN = 8
 )
+
+// ADC pins
+const (
+	ADCPin0 = 3
+	ADCPin1 = 4
+	ADCPin2 = 28
+	ADCPin3 = 29
+	ADCPin4 = 30
+	ADCPin5 = 31
+)

--- a/src/machine/i2c.go
+++ b/src/machine/i2c.go
@@ -2,19 +2,8 @@
 
 package machine
 
-type I2C struct {
-	Bus uint8
-}
-
-// TWI_FREQ is the bus speed. Normally either 100 kHz, or 400 kHz for high-speed bus.
+// TWI_FREQ is the I2C bus speed. Normally either 100 kHz, or 400 kHz for high-speed bus.
 const (
 	TWI_FREQ_100KHZ = 100000
 	TWI_FREQ_400KHZ = 400000
 )
-
-// I2CConfig does not do much of anything on Arduino.
-type I2CConfig struct {
-	Frequency uint32
-	SCL       uint8
-	SDA       uint8
-}

--- a/src/machine/i2c.go
+++ b/src/machine/i2c.go
@@ -3,6 +3,7 @@
 package machine
 
 type I2C struct {
+	Bus uint8
 }
 
 // TWI_FREQ is the bus speed. Normally either 100 kHz, or 400 kHz for high-speed bus.

--- a/src/machine/i2c.go
+++ b/src/machine/i2c.go
@@ -15,4 +15,6 @@ const (
 // I2CConfig does not do much of anything on Arduino.
 type I2CConfig struct {
 	Frequency uint32
+	SCL       uint8
+	SDA       uint8
 }

--- a/src/machine/i2c.go
+++ b/src/machine/i2c.go
@@ -1,0 +1,17 @@
+// +build avr nrf
+
+package machine
+
+type I2C struct {
+}
+
+// TWI_FREQ is the bus speed. Normally either 100 kHz, or 400 kHz for high-speed bus.
+const (
+	TWI_FREQ_100KHZ = 100000
+	TWI_FREQ_400KHZ = 400000
+)
+
+// I2CConfig does not do much of anything on Arduino.
+type I2CConfig struct {
+	Frequency uint32
+}

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -159,22 +159,9 @@ func (a ADC) Get() uint16 {
 }
 
 // I2C on the Arduino
-type I2C struct {
-}
 
 // I2C0 is the only I2C interface on the Arduino.
 var I2C0 = I2C{}
-
-// TWI_FREQ is the bus speed. Normally either 100 kHz, or 400 kHz for high-speed bus.
-const (
-	TWI_FREQ_100KHZ = 100000
-	TWI_FREQ_400KHZ = 400000
-)
-
-// I2CConfig does not do much of anything on Arduino.
-type I2CConfig struct {
-	Frequency uint32
-}
 
 // Configure is intended to setup the I2C interface.
 func (i2c I2C) Configure(config I2CConfig) {

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -158,10 +158,17 @@ func (a ADC) Get() uint16 {
 	return uint16(low) | uint16(high<<8)
 }
 
-// I2C on the Arduino
+// I2C on the Arduino.
+type I2C struct {
+}
 
 // I2C0 is the only I2C interface on the Arduino.
 var I2C0 = I2C{}
+
+// I2CConfig is used to store config info for I2C.
+type I2CConfig struct {
+	Frequency uint32
+}
 
 // Configure is intended to setup the I2C interface.
 func (i2c I2C) Configure(config I2CConfig) {

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -5,7 +5,6 @@ package machine
 import (
 	"device/arm"
 	"device/nrf"
-	"time"
 )
 
 type GPIOMode uint8
@@ -154,9 +153,6 @@ func (i2c I2C) WriteTo(address uint8, data []byte) {
 		i2c.WriteByte(v)
 	}
 
-	// Approx. 300 us needed after ending write before sending stop.
-	time.Sleep(300 * time.Microsecond)
-
 	// Assume stop after write.
 	i2c.Stop()
 }
@@ -171,8 +167,6 @@ func (i2c I2C) ReadFrom(address uint8, data []byte) {
 
 	// Assume stop after read.
 	i2c.Stop()
-
-	return
 }
 
 // WriteByte writes a single byte to the I2C bus.

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -117,15 +117,22 @@ func (i2c I2C) Configure(config I2CConfig) {
 	if config.Frequency == 0 {
 		config.Frequency = TWI_FREQ_100KHZ
 	}
+	// Default I2C pins.
+	if config.SDA == 0 {
+		config.SDA = SDA_PIN
+	}
+	if config.SCL == 0 {
+		config.SCL = SCL_PIN
+	}
 
 	// do config
-	nrf.P0.PIN_CNF[SCL_PIN] = (nrf.GPIO_PIN_CNF_DIR_Input << nrf.GPIO_PIN_CNF_DIR_Pos) |
+	nrf.P0.PIN_CNF[config.SCL] = (nrf.GPIO_PIN_CNF_DIR_Input << nrf.GPIO_PIN_CNF_DIR_Pos) |
 		(nrf.GPIO_PIN_CNF_INPUT_Connect << nrf.GPIO_PIN_CNF_INPUT_Pos) |
 		(nrf.GPIO_PIN_CNF_PULL_Pullup << nrf.GPIO_PIN_CNF_PULL_Pos) |
 		(nrf.GPIO_PIN_CNF_DRIVE_S0D1 << nrf.GPIO_PIN_CNF_DRIVE_Pos) |
 		(nrf.GPIO_PIN_CNF_SENSE_Disabled << nrf.GPIO_PIN_CNF_SENSE_Pos)
 
-	nrf.P0.PIN_CNF[SDA_PIN] = (nrf.GPIO_PIN_CNF_DIR_Input << nrf.GPIO_PIN_CNF_DIR_Pos) |
+	nrf.P0.PIN_CNF[config.SDA] = (nrf.GPIO_PIN_CNF_DIR_Input << nrf.GPIO_PIN_CNF_DIR_Pos) |
 		(nrf.GPIO_PIN_CNF_INPUT_Connect << nrf.GPIO_PIN_CNF_INPUT_Pos) |
 		(nrf.GPIO_PIN_CNF_PULL_Pullup << nrf.GPIO_PIN_CNF_PULL_Pos) |
 		(nrf.GPIO_PIN_CNF_DRIVE_S0D1 << nrf.GPIO_PIN_CNF_DRIVE_Pos) |
@@ -138,8 +145,8 @@ func (i2c I2C) Configure(config I2CConfig) {
 	}
 
 	i2c.register().ENABLE = nrf.TWI_ENABLE_ENABLE_Enabled
-	i2c.register().PSELSCL = SCL_PIN
-	i2c.register().PSELSDA = SDA_PIN
+	i2c.register().PSELSCL = nrf.RegValue(config.SCL)
+	i2c.register().PSELSDA = nrf.RegValue(config.SDA)
 }
 
 // Start starts an I2C communication session.

--- a/src/machine/machine_nrf52.go
+++ b/src/machine/machine_nrf52.go
@@ -1,0 +1,155 @@
+// +build nrf52
+
+package machine
+
+import (
+	"device/nrf"
+	"unsafe"
+)
+
+// InitADC initializes the registers needed for ADC.
+func InitADC() {
+	return // no specific setup on nrf52 machine.
+}
+
+// Configure configures an ADC pin to be able to read analog data.
+func (a ADC) Configure() {
+	return // no pin specific setup on nrf52 machine.
+}
+
+// Get returns the current value of a ADC pin in the range 0..0xffff.
+func (a ADC) Get() uint16 {
+	var pwmPin uint32
+	var value int16
+
+	switch a.Pin {
+	case 2:
+		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput0
+
+	case 3:
+		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput1
+
+	case 4:
+		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput2
+
+	case 5:
+		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput3
+
+	case 28:
+		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput4
+
+	case 29:
+		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput5
+
+	case 30:
+		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput6
+
+	case 31:
+		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput7
+
+	default:
+		return 0
+	}
+
+	// Set 14-bit sample resolution.
+	nrf.SAADC.RESOLUTION = nrf.SAADC_RESOLUTION_VAL_12bit
+
+	// Enable ADC.
+	nrf.SAADC.ENABLE = (nrf.SAADC_ENABLE_ENABLE_Enabled << nrf.SAADC_ENABLE_ENABLE_Pos)
+	for i := 0; i < 8; i++ {
+		nrf.SAADC.CH[i].PSELN = nrf.SAADC_CH_PSELP_PSELP_NC
+		nrf.SAADC.CH[i].PSELP = nrf.SAADC_CH_PSELP_PSELP_NC
+	}
+
+	// Configure ADC.
+	nrf.SAADC.CH[0].CONFIG = ((nrf.SAADC_CH_CONFIG_RESP_Bypass << nrf.SAADC_CH_CONFIG_RESP_Pos) & nrf.SAADC_CH_CONFIG_RESP_Msk) |
+		((nrf.SAADC_CH_CONFIG_RESP_Bypass << nrf.SAADC_CH_CONFIG_RESN_Pos) & nrf.SAADC_CH_CONFIG_RESN_Msk) |
+		((nrf.SAADC_CH_CONFIG_GAIN_Gain1_5 << nrf.SAADC_CH_CONFIG_GAIN_Pos) & nrf.SAADC_CH_CONFIG_GAIN_Msk) |
+		((nrf.SAADC_CH_CONFIG_REFSEL_Internal << nrf.SAADC_CH_CONFIG_REFSEL_Pos) & nrf.SAADC_CH_CONFIG_REFSEL_Msk) |
+		((nrf.SAADC_CH_CONFIG_TACQ_3us << nrf.SAADC_CH_CONFIG_TACQ_Pos) & nrf.SAADC_CH_CONFIG_TACQ_Msk) |
+		((nrf.SAADC_CH_CONFIG_MODE_SE << nrf.SAADC_CH_CONFIG_MODE_Pos) & nrf.SAADC_CH_CONFIG_MODE_Msk)
+
+	// Set pin to read.
+	nrf.SAADC.CH[0].PSELN = nrf.RegValue(pwmPin)
+	nrf.SAADC.CH[0].PSELP = nrf.RegValue(pwmPin)
+
+	// Destination for sample result.
+	nrf.SAADC.RESULT.PTR = nrf.RegValue(uintptr(unsafe.Pointer(&value)))
+	nrf.SAADC.RESULT.MAXCNT = 1 // One sample
+
+	// Start tasks.
+	nrf.SAADC.TASKS_START = 1
+	for nrf.SAADC.EVENTS_STARTED == 0 {
+	}
+	nrf.SAADC.EVENTS_STARTED = 0x00
+
+	// Start the sample task.
+	nrf.SAADC.TASKS_SAMPLE = 1
+
+	// Wait until the sample task is done.
+	for nrf.SAADC.EVENTS_END == 0 {
+	}
+	nrf.SAADC.EVENTS_END = 0x00
+
+	// Stop the ADC
+	nrf.SAADC.TASKS_STOP = 1
+	for nrf.SAADC.EVENTS_STOPPED == 0 {
+	}
+	nrf.SAADC.EVENTS_STOPPED = 0
+
+	// Disable the ADC.
+	nrf.SAADC.ENABLE = (nrf.SAADC_ENABLE_ENABLE_Disabled << nrf.SAADC_ENABLE_ENABLE_Pos)
+
+	if value < 0 {
+		value = 0
+	}
+
+	// Return 16-bit result from 12-bit value.
+	return uint16(value << 4)
+}
+
+// PWM
+var (
+	pwmChannelPins     = [3]uint32{0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF}
+	pwms               = [3]*nrf.PWM_Type{nrf.PWM0, nrf.PWM1, nrf.PWM2}
+	pwmChannelSequence [3]uint16
+)
+
+// InitPWM initializes the registers needed for PWM.
+func InitPWM() {
+	return
+}
+
+// Configure configures a PWM pin for output.
+func (pwm PWM) Configure() {
+}
+
+// Set turns on the duty cycle for a PWM pin using the provided value.
+func (pwm PWM) Set(value uint16) {
+	for i := 0; i < 3; i++ {
+		if pwmChannelPins[i] == 0xFFFFFFFF || pwmChannelPins[i] == uint32(pwm.Pin) {
+			pwmChannelPins[i] = uint32(pwm.Pin)
+			pwmChannelSequence[i] = value | 0x8000
+
+			p := pwms[i]
+
+			p.PSEL.OUT[0] = nrf.RegValue(pwm.Pin)
+			p.PSEL.OUT[1] = nrf.RegValue(pwm.Pin)
+			p.PSEL.OUT[2] = nrf.RegValue(pwm.Pin)
+			p.PSEL.OUT[3] = nrf.RegValue(pwm.Pin)
+			p.ENABLE = (nrf.PWM_ENABLE_ENABLE_Enabled << nrf.PWM_ENABLE_ENABLE_Pos)
+			p.PRESCALER = nrf.PWM_PRESCALER_PRESCALER_DIV_1
+			p.MODE = nrf.PWM_MODE_UPDOWN_Up
+			p.COUNTERTOP = (1 << 8) - 1
+			p.LOOP = 0
+			p.DECODER = (nrf.PWM_DECODER_LOAD_Common << nrf.PWM_DECODER_LOAD_Pos) | (nrf.PWM_DECODER_MODE_RefreshCount << nrf.PWM_DECODER_MODE_Pos)
+			p.SEQ[0].PTR = nrf.RegValue(uintptr(unsafe.Pointer(&pwmChannelSequence[i])))
+			p.SEQ[0].CNT = 1
+			p.SEQ[0].REFRESH = 1
+			p.SEQ[0].ENDDELAY = 0
+			p.TASKS_SEQSTART[0] = 1
+
+			break
+		}
+	}
+}

--- a/src/machine/machine_nrf52.go
+++ b/src/machine/machine_nrf52.go
@@ -129,7 +129,7 @@ func (pwm PWM) Set(value uint16) {
 	for i := 0; i < 3; i++ {
 		if pwmChannelPins[i] == 0xFFFFFFFF || pwmChannelPins[i] == uint32(pwm.Pin) {
 			pwmChannelPins[i] = uint32(pwm.Pin)
-			pwmChannelSequence[i] = value | 0x8000
+			pwmChannelSequence[i] = (value >> 2) | 0x8000 // set bit 15 to invert polarity
 
 			p := pwms[i]
 
@@ -138,9 +138,9 @@ func (pwm PWM) Set(value uint16) {
 			p.PSEL.OUT[2] = nrf.RegValue(pwm.Pin)
 			p.PSEL.OUT[3] = nrf.RegValue(pwm.Pin)
 			p.ENABLE = (nrf.PWM_ENABLE_ENABLE_Enabled << nrf.PWM_ENABLE_ENABLE_Pos)
-			p.PRESCALER = nrf.PWM_PRESCALER_PRESCALER_DIV_1
+			p.PRESCALER = nrf.PWM_PRESCALER_PRESCALER_DIV_2
 			p.MODE = nrf.PWM_MODE_UPDOWN_Up
-			p.COUNTERTOP = (1 << 8) - 1
+			p.COUNTERTOP = 16384 // frequency
 			p.LOOP = 0
 			p.DECODER = (nrf.PWM_DECODER_LOAD_Common << nrf.PWM_DECODER_LOAD_Pos) | (nrf.PWM_DECODER_MODE_RefreshCount << nrf.PWM_DECODER_MODE_Pos)
 			p.SEQ[0].PTR = nrf.RegValue(uintptr(unsafe.Pointer(&pwmChannelSequence[i])))


### PR DESCRIPTION
This PR adds the I2C implementation for NRF. It should work for both NRF52 and NRF51, but I have only tested with the former, so far.