### PR TITLE
Add vendor step to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ RUN wget -O- https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 
 COPY . /go/src/github.com/aykevl/tinygo
 
-RUN go install /go/src/github.com/aykevl/tinygo/
+RUN cd /go/src/github.com/aykevl/tinygo/ && \
+    dep ensure --vendor-only && \
+    go install /go/src/github.com/aykevl/tinygo/
 
 FROM golang:latest
 
@@ -18,6 +20,6 @@ COPY --from=0 /go/bin/tinygo /go/bin/tinygo
 RUN wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add - && \
     echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-7 main" >> /etc/apt/sources.list && \
     apt-get update && \
-    apt-get install -y llvm-7
+    apt-get install -y libllvm7
 
 ENTRYPOINT ["/go/bin/tinygo"]


### PR DESCRIPTION
The Dockerfile was missing the part where we download
the dependencies into the vendor folder. It was of course
working locally because I had a vendor folder already.