### PR TITLE
Fix compiler.go import order

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"go/build"
 	"go/constant"
+	"go/parser"
 	"go/token"
 	"go/types"
 	"os"
@@ -16,7 +17,6 @@ import (
 
 	"github.com/aykevl/go-llvm"
 	"github.com/aykevl/tinygo/ir"
-	"go/parser"
 	"golang.org/x/tools/go/loader"
 	"golang.org/x/tools/go/ssa"
 )


### PR DESCRIPTION
go/parser is part of the standard library.

No functional change.