### PR TITLE
tinygo: add 'tinygo' build tag

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 		DumpSSA:   config.dumpSSA,
 		RootDir:   sourceDir(),
 		GOPATH:    getGopath(),
-		BuildTags: spec.BuildTags,
+		BuildTags: append(spec.BuildTags, "tinygo"),
 	}
 	c, err := compiler.NewCompiler(pkgName, compilerConfig)
 	if err != nil {


### PR DESCRIPTION
This enables project to conditionally skip code that can't compile on tinygo.