### PR TITLE
docs: correct dependencies needed for AVR development

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -38,10 +38,10 @@ AVR (Arduino)
 The AVR backend has similar requirements as the `ARM Cortex-M`_ backend. It
 needs the following tools:
 
-    * binutils (``avr-objcopy``) for flashing.
-    * GCC (``avr-gcc``) for linking object files.
+    * binutils (``binutils-avr``) for flashing.
+    * GCC (``gcc-avr``) for linking object files.
     * libc (``avr-libc``), which is not installed on Debian as a dependency of
-      ``avr-gcc``.
+      ``gcc-avr``.
     * ``avrdude`` for flashing to an Arduino.
 
 WebAssembly


### PR DESCRIPTION
There were some minor errors in the listed dependencies needed for AVR development. This PR corrects them in the docs.