### PR TITLE
Add support to Dockerfile for AVR and ARM target stages for MCU development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:latest
+# TinyGo base stage just installs LLVM 7 and the TinyGo compiler itself.
+FROM golang:latest AS tinygo-base
 
 RUN wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add - && \
     echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-7 main" >> /etc/apt/sources.list && \
@@ -13,11 +14,12 @@ RUN cd /go/src/github.com/aykevl/tinygo/ && \
     dep ensure --vendor-only && \
     go install /go/src/github.com/aykevl/tinygo/
 
-FROM golang:latest
+# tinygo-core stage installs the rest of TinyGo runtime. This is the default.
+FROM golang:latest AS tinygo-core
 
-COPY --from=0 /go/bin/tinygo /go/bin/tinygo
-COPY --from=0 /go/src/github.com/aykevl/tinygo/src /go/src/github.com/aykevl/tinygo/src
-COPY --from=0 /go/src/github.com/aykevl/tinygo/targets /go/src/github.com/aykevl/tinygo/targets
+COPY --from=tinygo-base /go/bin/tinygo /go/bin/tinygo
+COPY --from=tinygo-base /go/src/github.com/aykevl/tinygo/src /go/src/github.com/aykevl/tinygo/src
+COPY --from=tinygo-base /go/src/github.com/aykevl/tinygo/targets /go/src/github.com/aykevl/tinygo/targets
 
 RUN wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add - && \
     echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-7 main" >> /etc/apt/sources.list && \
@@ -25,3 +27,30 @@ RUN wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add - && \
     apt-get install -y libllvm7 lld-7
 
 ENTRYPOINT ["/go/bin/tinygo"]
+
+# tinygo-avr stage installs the needed dependencies to compile TinyGo programs for AVR microcontrollers.
+FROM tinygo-core AS tinygo-avr
+
+COPY --from=tinygo-base /go/src/github.com/aykevl/tinygo/Makefile /go/src/github.com/aykevl/tinygo/
+COPY --from=tinygo-base /go/src/github.com/aykevl/tinygo/tools /go/src/github.com/aykevl/tinygo/tools
+COPY --from=tinygo-base /go/src/github.com/aykevl/tinygo/lib /go/src/github.com/aykevl/tinygo/lib
+
+RUN cd /go/src/github.com/aykevl/tinygo/ && \
+    apt-get update && \
+    apt-get install -y apt-utils python3 make binutils-avr gcc-avr avr-libc && \
+    make gen-device-avr
+
+# tinygo-arm stage installs the needed dependencies to compile TinyGo programs for ARM microcontrollers.
+FROM tinygo-core AS tinygo-arm
+
+COPY --from=tinygo-base /go/src/github.com/aykevl/tinygo/Makefile /go/src/github.com/aykevl/tinygo/
+COPY --from=tinygo-base /go/src/github.com/aykevl/tinygo/tools /go/src/github.com/aykevl/tinygo/tools
+COPY --from=tinygo-base /go/src/github.com/aykevl/tinygo/lib /go/src/github.com/aykevl/tinygo/lib
+
+RUN cd /go/src/github.com/aykevl/tinygo/ && \
+    apt-get update && \
+    apt-get install -y apt-utils python3 make gcc-arm-none-eabi clang-7 && \
+    make gen-device-nrf && make gen-device-stm32
+
+# Default to tinygo-core
+FROM tinygo-core

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,5 +58,14 @@ RUN cd /go/src/github.com/aykevl/tinygo/ && \
     apt-get install -y apt-utils python3 make gcc-arm-none-eabi clang-7 && \
     make gen-device-nrf && make gen-device-stm32
 
-# Default to tinygo-wasm stage for now...
-FROM tinygo-wasm
+# tinygo-all stage installs the needed dependencies to compile TinyGo programs for all platforms.
+FROM tinygo-wasm AS tinygo-all
+
+COPY --from=tinygo-base /go/src/github.com/aykevl/tinygo/Makefile /go/src/github.com/aykevl/tinygo/
+COPY --from=tinygo-base /go/src/github.com/aykevl/tinygo/tools /go/src/github.com/aykevl/tinygo/tools
+COPY --from=tinygo-base /go/src/github.com/aykevl/tinygo/lib /go/src/github.com/aykevl/tinygo/lib
+
+RUN cd /go/src/github.com/aykevl/tinygo/ && \
+    apt-get update && \
+    apt-get install -y apt-utils python3 make gcc-arm-none-eabi clang-7 binutils-avr gcc-avr avr-libc && \
+    make gen-device

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,10 @@ COPY --from=tinygo-base /go/src/github.com/aykevl/tinygo/lib /go/src/github.com/
 RUN cd /go/src/github.com/aykevl/tinygo/ && \
     apt-get update && \
     apt-get install -y apt-utils python3 make binutils-avr gcc-avr avr-libc && \
-    make gen-device-avr
+    make gen-device-avr && \
+    apt-get remove -y python3 make && \
+    apt-get autoremove -y && \
+    apt-get clean
 
 # tinygo-arm stage installs the needed dependencies to compile TinyGo programs for ARM microcontrollers.
 FROM tinygo-base AS tinygo-arm
@@ -56,7 +59,10 @@ COPY --from=tinygo-base /go/src/github.com/aykevl/tinygo/lib /go/src/github.com/
 RUN cd /go/src/github.com/aykevl/tinygo/ && \
     apt-get update && \
     apt-get install -y apt-utils python3 make gcc-arm-none-eabi clang-7 && \
-    make gen-device-nrf && make gen-device-stm32
+    make gen-device-nrf && make gen-device-stm32 && \
+    apt-get remove -y python3 make && \
+    apt-get autoremove -y && \
+    apt-get clean
 
 # tinygo-all stage installs the needed dependencies to compile TinyGo programs for all platforms.
 FROM tinygo-wasm AS tinygo-all
@@ -68,4 +74,8 @@ COPY --from=tinygo-base /go/src/github.com/aykevl/tinygo/lib /go/src/github.com/
 RUN cd /go/src/github.com/aykevl/tinygo/ && \
     apt-get update && \
     apt-get install -y apt-utils python3 make gcc-arm-none-eabi clang-7 binutils-avr gcc-avr avr-libc && \
-    make gen-device
+    make gen-device && \
+    apt-get remove -y python3 make && \
+    apt-get autoremove -y && \
+    apt-get clean
+

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -11,5 +11,19 @@ repository::
 
     docker run --rm -v $(pwd):/src tinygo/tinygo build -o /src/wasm.wasm -target wasm examples/wasm
 
-Note that you cannot run ``tinygo flash`` from inside the docker container,
-so it is less useful for microcontroller development.
+To compile ``blinky1.hex`` targeting an ARM microcontroller, such as the PCA10040::
+
+    docker run --rm -v $(pwd):/src tinygo/tinygo build -o /src/blinky1.hex -size=short -target=pca10040 examples/blinky1
+
+To compile ``blinky1.hex`` targeting an AVR microcontroller such as the Arduino::
+
+    docker run --rm -v $(pwd):/src tinygo/tinygo build -o /src/blinky1.hex -size=short -target=arduino examples/blinky1
+
+Note that for microcontroller development you must flash your hardware devices 
+from your host environment, since you cannot run ``tinygo flash`` from inside 
+the docker container.
+
+So your workflow could be:
+
+- Compile TinyGo code using the Docker container into a HEX file.
+- Flash the HEX file from your host environment to the target microcontroller.


### PR DESCRIPTION
This PR extends the Dockerfile by adding some additional stages intended to be used for MCU development.

To use the AVR stage, use the `--target=tinygo-avr` flag when building the image.

To compile TinyGo code for AVR:

```
docker run --rm -v $(pwd):/src hybridgroup/tinygo-avr build -o /src/blinky1.elf -size=short -target=arduino examples/blinky1
```

To use the ARM stage, use the `--target=tinygo-arm` flag when building the image.

To compile TinyGo code targeting ARM:

```
docker run --rm -v $(pwd):/src hybridgroup/tinygo-arm build -o /src/blinky1.elf -size=short -target=pca10040 examples/blinky1
```

The default for the Dockerfile is to build the `tinygo-wasm` stage for WASM development. This is the same as the `--target=tinygo-avr` flag.

To compile TinyGo code targeting WASM:

```
docker run --rm -v $(pwd):/src hybridgroup/tinygo-wasm build -o /src/wasm.wasm -target wasm examples/wasm
```
