### PR TITLE
all: rename 'arm' to 'tinygo.arm' for Cortex-M

### DIFF
--- a/src/runtime/arch_tinygoarm.go
+++ b/src/runtime/arch_tinygoarm.go
@@ -1,4 +1,4 @@
-// +build arm
+// +build tinygo.arm
 
 package runtime
 

--- a/src/runtime/arch_wasm.go
+++ b/src/runtime/arch_wasm.go
@@ -1,4 +1,4 @@
-// +build wasm,!arm,!avr
+// +build wasm,!tinygo.arm,!avr
 
 package runtime
 

--- a/src/runtime/override_js.go
+++ b/src/runtime/override_js.go
@@ -1,4 +1,4 @@
-// +build js,arm avr
+// +build js,tinygo.arm avr
 
 package runtime
 

--- a/src/runtime/runtime_tinygoarm.go
+++ b/src/runtime/runtime_tinygoarm.go
@@ -1,4 +1,4 @@
-/// +build arm
+// +build tinygo.arm
 
 package runtime
 

--- a/src/runtime/runtime_wasm.go
+++ b/src/runtime/runtime_wasm.go
@@ -1,4 +1,4 @@
-// +build wasm,!arm,!avr
+// +build wasm,!tinygo.arm,!avr
 
 package runtime
 

--- a/targets/bluepill.json
+++ b/targets/bluepill.json
@@ -1,6 +1,6 @@
 {
 	"llvm-target": "armv7m-none-eabi",
-	"build-tags": ["bluepill", "stm32f103xx", "stm32", "arm", "js", "wasm"],
+	"build-tags": ["bluepill", "stm32f103xx", "stm32", "tinygo.arm", "js", "wasm"],
 	"linker": "arm-none-eabi-gcc",
 	"compiler-rt": true,
 	"pre-link-args": ["-nostdlib", "-nostartfiles", "-mcpu=cortex-m3", "-mthumb", "-T", "targets/stm32.ld", "-Wl,--gc-sections", "-fno-exceptions", "-fno-unwind-tables", "-ffunction-sections", "-fdata-sections", "-Os", "src/device/stm32/stm32f103xx.s"],

--- a/targets/microbit.json
+++ b/targets/microbit.json
@@ -1,6 +1,6 @@
 {
 	"llvm-target": "armv6m-none-eabi",
-	"build-tags": ["microbit", "nrf51822", "nrf51", "nrf", "arm", "js", "wasm"],
+	"build-tags": ["microbit", "nrf51822", "nrf51", "nrf", "tinygo.arm", "js", "wasm"],
 	"linker": "arm-none-eabi-gcc",
 	"compiler-rt": true,
 	"pre-link-args": [

--- a/targets/nrf52840-mdk.json
+++ b/targets/nrf52840-mdk.json
@@ -1,6 +1,6 @@
 {
 	"llvm-target": "armv7em-none-eabi",
-	"build-tags": ["nrf52840_mdk", "nrf52840", "nrf", "arm", "js", "wasm"],
+	"build-tags": ["nrf52840_mdk", "nrf52840", "nrf", "tinygo.arm", "js", "wasm"],
 	"linker": "arm-none-eabi-gcc",
 	"pre-link-args": [
 		"-nostdlib",

--- a/targets/pca10040.json
+++ b/targets/pca10040.json
@@ -1,6 +1,6 @@
 {
 	"llvm-target": "armv7em-none-eabi",
-	"build-tags": ["pca10040", "nrf52832", "nrf52", "nrf", "arm", "js", "wasm"],
+	"build-tags": ["pca10040", "nrf52832", "nrf52", "nrf", "tinygo.arm", "js", "wasm"],
 	"linker": "arm-none-eabi-gcc",
 	"compiler-rt": true,
 	"pre-link-args": [

--- a/targets/qemu.json
+++ b/targets/qemu.json
@@ -1,6 +1,6 @@
 {
 	"llvm-target": "armv7m-none-eabi",
-	"build-tags": ["qemu", "lm3s6965", "arm", "js", "wasm"],
+	"build-tags": ["qemu", "lm3s6965", "tinygo.arm", "js", "wasm"],
 	"linker": "arm-none-eabi-gcc",
 	"compiler-rt": true,
 	"pre-link-args": [


### PR DESCRIPTION
Let the standard library think that it is compiling for js/wasm.

The most correct way of supporting bare metal Cortex-M targets would be
using the 'arm' build tag and specifying no OS or an 'undefined' OS
(perhaps GOOS=noos?). However, there is no build tag for specifying no
OS at all, the closest possible is GOOS=js which makes very few
assumptions.

Sadly GOOS=js also makes some assumptions: it assumes to be running with
GOARCH=wasm. This would not be such a problem, just add js, wasm and arm
as build tags. However, having two GOARCH build tags leads to an error
in internal/cpu: it defines variables for both architectures which then
conflict.

To work around these problems, the 'arm' target has been renamed to
'tinygo.arm', which should work around these problems. In the future, a
GOOS=noos (or similar) should be added which can work with any
architecture and doesn't implement OS-specific stuff.