### PR TITLE
Minor fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . /go/src/github.com/aykevl/tinygo
 
 RUN cd /go/src/github.com/aykevl/tinygo/ && \
     dep ensure --vendor-only && \
-    go install /go/src/github.com/aykevl/tinygo/
+    go install github.com/aykevl/tinygo
 
 FROM golang:latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,13 @@ RUN cd /go/src/github.com/aykevl/tinygo/ && \
 
 FROM golang:latest
 
-COPY --from=0 /go/bin/tinygo /go/bin/tinygo
-COPY --from=0 /go/src/github.com/aykevl/tinygo/src /go/src/github.com/aykevl/tinygo/src
-COPY --from=0 /go/src/github.com/aykevl/tinygo/targets /go/src/github.com/aykevl/tinygo/targets
-
 RUN wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add - && \
     echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-7 main" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y libllvm7 lld-7
+
+COPY --from=0 /go/bin/tinygo /go/bin/tinygo
+COPY --from=0 /go/src/github.com/aykevl/tinygo/src /go/src/github.com/aykevl/tinygo/src
+COPY --from=0 /go/src/github.com/aykevl/tinygo/targets /go/src/github.com/aykevl/tinygo/targets
 
 ENTRYPOINT ["/go/bin/tinygo"]

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -2527,7 +2527,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		}
 
 		if expr.High != nil {
-			highType = expr.High.Type().(*types.Basic)
+			highType = expr.High.Type().Underlying().(*types.Basic)
 			high, err = c.parseExpr(frame, expr.High)
 			if err != nil {
 				return llvm.Value{}, nil


### PR DESCRIPTION
* Use the package name instead of the full path when installing tinygo in Docker (fails with recent Go images).
* Fix another usage of a named type (`*types.Basic`).
* Place the LLVM installation as a first step in the final image. This preserves it as a cache when recompiling tinygo.