### PR TITLE
Add support for PCA10031 nrf51 wireless dongle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,12 @@ script:
   - go install github.com/aykevl/tinygo
   - go test -v .
   - make gen-device
-  - tinygo build -o blinky1.nrf.elf   -target=pca10040     examples/blinky1
-  - tinygo build -o blinky2.nrf.elf   -target=pca10040     examples/blinky2
-  - tinygo build -o blinky2                                examples/blinky2
-  - tinygo build -o test.nrf.elf      -target=pca10040     examples/test
-  - tinygo build -o blinky1.nrf51.elf -target=microbit     examples/echo
-  - tinygo build -o test.nrf.elf      -target=nrf52840-mdk examples/blinky1
-  - tinygo build -o blinky1.stm32.elf -target=bluepill     examples/blinky1
-  - tinygo build -o blinky1.avr.o     -target=arduino      examples/blinky1 # TODO: avr-as/avr-gcc doesn't work
+  - tinygo build -o blinky1.nrf51d.elf -target=pca10031     examples/blinky1  
+  - tinygo build -o blinky1.nrf.elf    -target=pca10040     examples/blinky1
+  - tinygo build -o blinky2.nrf.elf    -target=pca10040     examples/blinky2
+  - tinygo build -o blinky2                                 examples/blinky2
+  - tinygo build -o test.nrf.elf       -target=pca10040     examples/test
+  - tinygo build -o blinky1.nrf51.elf  -target=microbit     examples/echo
+  - tinygo build -o test.nrf.elf       -target=nrf52840-mdk examples/blinky1
+  - tinygo build -o blinky1.stm32.elf  -target=bluepill     examples/blinky1
+  - tinygo build -o blinky1.avr.o      -target=arduino      examples/blinky1 # TODO: avr-as/avr-gcc doesn't work

--- a/docs/targets.rst
+++ b/docs/targets.rst
@@ -28,6 +28,10 @@ technology (LLVM) as the proprietary ARM compiler for code generation.
 
   * `BBC micro:bit <https://microbit.org/>`_ (`nRF51822
     <https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF51822>`_)
+  * `Nordic PCA10031
+    <https://www.nordicsemi.com/eng/Products/nRF51-Dongle>`_
+    (`nRF51422
+    <https://www.nordicsemi.com/eng/Products/ANT/nRF51422>`_)
   * `Nordic PCA10040
     <https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF52-DK>`_
     (`nRF52832

--- a/src/machine/board_pca10031.go
+++ b/src/machine/board_pca10031.go
@@ -13,6 +13,7 @@ const (
 	LED       = LED_RED
 	LED1      = LED_RED
 	LED2      = LED_GREEN
+	LED3      = LED_BLUE
 	LED_RED   = 21
 	LED_GREEN = 22
 	LED_BLUE  = 23
@@ -26,6 +27,6 @@ const (
 
 // I2C pins (disabled)
 const (
-	SDA_PIN = 0xff
-	SCL_PIN = 0xff
+	SDA_PIN = 0xffffffff
+	SCL_PIN = 0xffffffff
 )

--- a/src/machine/board_pca10031.go
+++ b/src/machine/board_pca10031.go
@@ -1,0 +1,31 @@
+// +build nrf51,pca10031
+
+// pca10031 is a nrf51 based dongle, intended for use in wireless applications.
+//
+// https://infocenter.nordicsemi.com/pdf/nRF51_Dongle_UG_v1.0.pdf
+package machine
+
+// The pca10031 has a 32kHz crystal on board.
+const HasLowFrequencyCrystal = true
+
+// LED on the pca10031
+const (
+	LED       = LED_RED
+	LED1      = LED_RED
+	LED2      = LED_GREEN
+	LED_RED   = 21
+	LED_GREEN = 22
+	LED_BLUE  = 23
+)
+
+// UART pins
+const (
+	UART_TX_PIN = 9
+	UART_RX_PIN = 11
+)
+
+// I2C pins (disabled)
+const (
+	SDA_PIN = 0xff
+	SCL_PIN = 0xff
+)

--- a/src/machine/board_pca10031.go
+++ b/src/machine/board_pca10031.go
@@ -27,6 +27,6 @@ const (
 
 // I2C pins (disabled)
 const (
-	SDA_PIN = 0xffffffff
-	SCL_PIN = 0xffffffff
+	SDA_PIN = 0xff
+	SCL_PIN = 0xff
 )

--- a/targets/pca10031.json
+++ b/targets/pca10031.json
@@ -1,0 +1,7 @@
+{
+	"inherits": ["nrf51"],
+	"build-tags": ["pca10031"],
+	"flash": "nrfjprog -f nrf51 --sectorerase --program {hex} --reset",
+	"ocd-daemon": ["openocd", "-f", "interface/cmsis-dap.cfg", "-f", "target/nrf51.cfg"],
+	"gdb-initial-cmds": ["target remote :3333", "monitor halt", "load", "monitor reset", "c"]
+}


### PR DESCRIPTION
This PR adds support for the PCA10031 nrf51 wireless dongle.

https://infocenter.nordicsemi.com/pdf/nRF51_Dongle_UG_v1.0.pdf