### PR TITLE
Enable tinygo/docker to resolve go dependencies

### DIFF
--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -21,7 +21,7 @@ To compile ``blinky1.hex`` targeting an AVR microcontroller such as the Arduino:
 
 For projects that have remote dependencies outside of the standard library and go code within your own project, you will need to map your entire GOROOT into the docker image in order for those dependencies to be found.  
 
-    docker run  -v $(PWD):/mysrc -v $GOPATH:/mycode -e "GOPATH=$GOPATH:/mycode" tinygo/tinygo build -o /mysrc/wasmout.wasm -target wasm /mysrc/wasm-main.go
+    docker run  -v $(PWD):/mysrc -v $GOPATH:/gohost -e "GOPATH=$GOPATH:/gohost" tinygo/tinygo build -o /mysrc/wasmout.wasm -target wasm /mysrc/wasm-main.go
 
 NOTE: 
 - At this time, tinygo does not resolve dependencies from the /vendor/ folder within your project. 

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -19,14 +19,14 @@ To compile ``blinky1.hex`` targeting an AVR microcontroller such as the Arduino:
 
     docker run --rm -v $(pwd):/src tinygo/tinygo build -o /src/blinky1.hex -size=short -target=arduino examples/blinky1
 
-For projects that have remote dependencies outside of the standard library and go code within your own project, you will need to map your entire GOROOT into the docker image in order for those dependencies to be found.  
+For projects that have remote dependencies outside of the standard library and go code within your own project, you will need to map your entire GOPATH into the docker image in order for those dependencies to be found::
 
     docker run  -v $(PWD):/mysrc -v $GOPATH:/gohost -e "GOPATH=$GOPATH:/gohost" tinygo/tinygo build -o /mysrc/wasmout.wasm -target wasm /mysrc/wasm-main.go
 
-NOTE: 
-- At this time, tinygo does not resolve dependencies from the /vendor/ folder within your project. 
+.. note::
+  At this time, tinygo does not resolve dependencies from the /vendor/ folder within your project. 
 
-Note that for microcontroller development you must flash your hardware devices 
+For microcontroller development you must flash your hardware devices 
 from your host environment, since you cannot run ``tinygo flash`` from inside 
 the docker container.
 

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -19,6 +19,13 @@ To compile ``blinky1.hex`` targeting an AVR microcontroller such as the Arduino:
 
     docker run --rm -v $(pwd):/src tinygo/tinygo build -o /src/blinky1.hex -size=short -target=arduino examples/blinky1
 
+For projects that have remote dependencies outside of the standard library and go code within your own project, you will need to map your entire GOROOT into the docker image in order for those dependencies to be found.  
+
+    docker run  -v $(PWD):/mysrc -v $GOPATH:/mycode -e "GOPATH=$GOPATH:/mycode" tinygo/tinygo build -o /mysrc/wasmout.wasm -target wasm /mysrc/wasm-main.go
+
+NOTE: 
+- At this time, tinygo does not resolve dependencies from the /vendor/ folder within your project. 
+
 Note that for microcontroller development you must flash your hardware devices 
 from your host environment, since you cannot run ``tinygo flash`` from inside 
 the docker container.


### PR DESCRIPTION
Example for mapping the GOPATH into the tinygo docker image so that go dependencies installed on the host can be found by the image.