### PR TITLE
WIP: new package loader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main"            | sudo tee -a /etc/apt/sources.list
   - echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -qq
-  - sudo apt-get install llvm-7-dev clang-7 binutils-arm-none-eabi qemu-system-arm --allow-unauthenticated -y
+  - sudo apt-get install llvm-7-dev clang-7 libclang-7-dev binutils-arm-none-eabi qemu-system-arm --allow-unauthenticated -y
   - sudo ln -s /usr/bin/clang-7 /usr/local/bin/cc # work around missing -no-pie in old GCC version
 
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:latest AS tinygo-base
 RUN wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add - && \
     echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-7 main" >> /etc/apt/sources.list && \
     apt-get update && \
-    apt-get install -y llvm-7-dev
+    apt-get install -y llvm-7-dev libclang-7-dev
 
 RUN wget -O- https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ clean:
 	@rm -rf build
 
 fmt:
-	@go fmt . ./compiler ./interp ./ir ./src/device/arm ./src/examples/* ./src/machine ./src/runtime ./src/sync
+	@go fmt . ./compiler ./interp ./loader ./ir ./src/device/arm ./src/examples/* ./src/machine ./src/runtime ./src/sync
 	@go fmt ./testdata/*.go
 
 test:

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -149,6 +149,10 @@ func NewCompiler(pkgName string, config Config) (*Compiler, error) {
 	return c, nil
 }
 
+func (c *Compiler) Packages() []*loader.Package {
+	return c.ir.LoaderProgram.Sorted()
+}
+
 // Return the LLVM module. Only valid after a successful compile.
 func (c *Compiler) Module() llvm.Module {
 	return c.mod

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -32,6 +32,7 @@ func init() {
 type Config struct {
 	Triple     string   // LLVM target triple, e.g. x86_64-unknown-linux-gnu (empty string means default)
 	GC         string   // garbage collection strategy
+	CFlags     []string // flags to pass to cgo
 	DumpSSA    bool     // dump Go SSA, for compiler debugging
 	Debug      bool     // add debug symbols for gdb
 	RootDir    string   // GOROOT for TinyGo
@@ -208,7 +209,8 @@ func (c *Compiler) Compile(mainPath string) error {
 				MaxAlign: int64(c.targetData.PrefTypeAlignment(c.i8ptrType)),
 			},
 		},
-		Dir: wd,
+		Dir:    wd,
+		CFlags: c.CFlags,
 	}
 	if strings.HasSuffix(mainPath, ".go") {
 		_, err = lprogram.ImportFile(mainPath)

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -19,6 +19,7 @@ import (
 // results.
 type Program struct {
 	Program        *ssa.Program
+	LoaderProgram  *loader.Program
 	mainPkg        *ssa.Package
 	Functions      []*Function
 	functionMap    map[*ssa.Function]*Function
@@ -172,11 +173,12 @@ func NewProgram(lprogram *loader.Program, mainPath string) *Program {
 	}
 
 	p := &Program{
-		Program:     program,
-		mainPkg:     mainPkg,
-		functionMap: make(map[*ssa.Function]*Function),
-		globalMap:   make(map[*ssa.Global]*Global),
-		comments:    comments,
+		Program:       program,
+		LoaderProgram: lprogram,
+		mainPkg:       mainPkg,
+		functionMap:   make(map[*ssa.Function]*Function),
+		globalMap:     make(map[*ssa.Global]*Global),
+		comments:      comments,
 	}
 
 	for _, pkg := range packageList {

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -8,9 +8,8 @@ import (
 	"strings"
 
 	"github.com/aykevl/go-llvm"
-	"golang.org/x/tools/go/loader"
+	"github.com/aykevl/tinygo/loader"
 	"golang.org/x/tools/go/ssa"
-	"golang.org/x/tools/go/ssa/ssautil"
 )
 
 // This file provides a wrapper around go/ssa values and adds extra
@@ -78,7 +77,7 @@ type Interface struct {
 // Create and intialize a new *Program from a *ssa.Program.
 func NewProgram(lprogram *loader.Program, mainPath string) *Program {
 	comments := map[string]*ast.CommentGroup{}
-	for _, pkgInfo := range lprogram.AllPackages {
+	for _, pkgInfo := range lprogram.Sorted() {
 		for _, file := range pkgInfo.Files {
 			for _, decl := range file.Decls {
 				switch decl := decl.(type) {
@@ -106,7 +105,7 @@ func NewProgram(lprogram *loader.Program, mainPath string) *Program {
 		}
 	}
 
-	program := ssautil.CreateProgram(lprogram, ssa.SanityCheckFunctions|ssa.BareInits|ssa.GlobalDebug)
+	program := lprogram.LoadSSA()
 	program.Build()
 
 	// Find the main package, which is a bit difficult when running a .go file

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -362,7 +362,12 @@ func (f *Function) LinkName() string {
 func (f *Function) CName() string {
 	name := f.Name()
 	if strings.HasPrefix(name, "_Cfunc_") {
+		// emitted by `go tool cgo`
 		return name[len("_Cfunc_"):]
+	}
+	if strings.HasPrefix(name, "C.") {
+		// created by ../loader/cgo.go
+		return name[2:]
 	}
 	return ""
 }

--- a/loader/cgo.go
+++ b/loader/cgo.go
@@ -1,0 +1,234 @@
+package loader
+
+// This file extracts the `import "C"` statement from the source and modifies
+// the AST for Cgo. It does not use libclang directly (see libclang.go).
+
+import (
+	"go/ast"
+	"go/token"
+	"strconv"
+)
+
+// fileInfo holds all Cgo-related information of a given *ast.File.
+type fileInfo struct {
+	*ast.File
+	filename   string
+	functions  []*functionInfo
+	types      []string
+	importCPos token.Pos
+}
+
+// functionInfo stores some information about a Cgo function found by libclang
+// and declared in the AST.
+type functionInfo struct {
+	name   string
+	args   []paramInfo
+	result string
+}
+
+// paramInfo is a parameter of a Cgo function (see functionInfo).
+type paramInfo struct {
+	name     string
+	typeName string
+}
+
+// aliasInfo encapsulates aliases between C and Go, like C.int32_t -> int32. See
+// addTypeAliases.
+type aliasInfo struct {
+	typeName   string
+	goTypeName string
+}
+
+// processCgo extracts the `import "C"` statement from the AST, parses the
+// comment with libclang, and modifies the AST to use this information.
+func (p *Package) processCgo(filename string, f *ast.File) error {
+	info := &fileInfo{
+		File:     f,
+		filename: filename,
+	}
+
+	// Find `import "C"` statements in the file.
+	for i := 0; i < len(f.Decls); i++ {
+		decl := f.Decls[i]
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		if len(genDecl.Specs) != 1 {
+			continue
+		}
+		spec, ok := genDecl.Specs[0].(*ast.ImportSpec)
+		if !ok {
+			continue
+		}
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			panic("could not parse import path: " + err.Error())
+		}
+		if path != "C" {
+			continue
+		}
+		cgoComment := genDecl.Doc.Text()
+
+		// Stored for later use by generated functions, to use a somewhat sane
+		// source location.
+		info.importCPos = spec.Path.ValuePos
+
+		err = info.parseFragment(cgoComment)
+		if err != nil {
+			return err
+		}
+
+		// Remove this import declaration.
+		f.Decls = append(f.Decls[:i], f.Decls[i+1:]...)
+		i--
+	}
+
+	// Print the AST, for debugging.
+	//ast.Print(p.fset, f)
+
+	// Declare functions found by libclang.
+	info.addFuncDecls()
+
+	// Forward C types to Go types (like C.uint32_t -> uint32).
+	info.addTypeAliases()
+
+	// Patch the AST to use the declared types and functions.
+	ast.Inspect(f, info.walker)
+
+	return nil
+}
+
+// addFuncDecls adds the C function declarations found by libclang in the
+// comment above the `import "C"` statement.
+func (info *fileInfo) addFuncDecls() {
+	// TODO: replace all uses of importCPos with the real locations from
+	// libclang.
+	for _, fn := range info.functions {
+		obj := &ast.Object{
+			Kind: ast.Fun,
+			Name: "C." + fn.name,
+		}
+		args := make([]*ast.Field, len(fn.args))
+		decl := &ast.FuncDecl{
+			Name: &ast.Ident{
+				NamePos: info.importCPos,
+				Name:    "C." + fn.name,
+				Obj:     obj,
+			},
+			Type: &ast.FuncType{
+				Func: info.importCPos,
+				Params: &ast.FieldList{
+					Opening: info.importCPos,
+					List:    args,
+					Closing: info.importCPos,
+				},
+				Results: &ast.FieldList{
+					List: []*ast.Field{
+						&ast.Field{
+							Type: &ast.Ident{
+								NamePos: info.importCPos,
+								Name:    "C." + fn.result,
+							},
+						},
+					},
+				},
+			},
+		}
+		obj.Decl = decl
+		for i, arg := range fn.args {
+			args[i] = &ast.Field{
+				Names: []*ast.Ident{
+					&ast.Ident{
+						NamePos: info.importCPos,
+						Name:    arg.name,
+						Obj: &ast.Object{
+							Kind: ast.Var,
+							Name: "C." + arg.name,
+							Decl: decl,
+						},
+					},
+				},
+				Type: &ast.Ident{
+					NamePos: info.importCPos,
+					Name:    "C." + arg.typeName,
+				},
+			}
+		}
+		info.Decls = append(info.Decls, decl)
+	}
+}
+
+// addTypeAliases aliases some built-in Go types with their equivalent C types.
+// It adds code like the following to the AST:
+//
+//     type (
+//         C.int8_t  = int8
+//         C.int16_t = int16
+//         // ...
+//     )
+func (info *fileInfo) addTypeAliases() {
+	aliases := []aliasInfo{
+		aliasInfo{"C.int8_t", "int8"},
+		aliasInfo{"C.int16_t", "int16"},
+		aliasInfo{"C.int32_t", "int32"},
+		aliasInfo{"C.int64_t", "int64"},
+		aliasInfo{"C.uint8_t", "uint8"},
+		aliasInfo{"C.uint16_t", "uint16"},
+		aliasInfo{"C.uint32_t", "uint32"},
+		aliasInfo{"C.uint64_t", "uint64"},
+		aliasInfo{"C.uintptr_t", "uintptr"},
+	}
+	gen := &ast.GenDecl{
+		TokPos: info.importCPos,
+		Tok:    token.TYPE,
+		Lparen: info.importCPos,
+		Rparen: info.importCPos,
+	}
+	for _, alias := range aliases {
+		obj := &ast.Object{
+			Kind: ast.Typ,
+			Name: alias.typeName,
+		}
+		typeSpec := &ast.TypeSpec{
+			Name: &ast.Ident{
+				NamePos: info.importCPos,
+				Name:    alias.typeName,
+				Obj:     obj,
+			},
+			Assign: info.importCPos,
+			Type: &ast.Ident{
+				NamePos: info.importCPos,
+				Name:    alias.goTypeName,
+			},
+		}
+		obj.Decl = typeSpec
+		gen.Specs = append(gen.Specs, typeSpec)
+	}
+	info.Decls = append(info.Decls, gen)
+}
+
+// walker replaces all "C".<something> call expressions to literal
+// "C.<something>" expressions. This is impossible to write in Go (a dot cannot
+// be used in the middle of a name) so is used as a new namespace for C call
+// expressions.
+func (info *fileInfo) walker(node ast.Node) bool {
+	switch node := node.(type) {
+	case *ast.CallExpr:
+		fun, ok := node.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		x, ok := fun.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if x.Name == "C" {
+			node.Fun = &ast.Ident{
+				NamePos: x.NamePos,
+				Name:    "C." + fun.Sel.Name,
+			}
+		}
+	}
+	return true
+}

--- a/loader/cgo.go
+++ b/loader/cgo.go
@@ -73,7 +73,7 @@ typedef unsigned long long  _Cgo_ulonglong;
 
 // processCgo extracts the `import "C"` statement from the AST, parses the
 // comment with libclang, and modifies the AST to use this information.
-func (p *Package) processCgo(filename string, f *ast.File) error {
+func (p *Package) processCgo(filename string, f *ast.File, cflags []string) error {
 	info := &fileInfo{
 		File:     f,
 		filename: filename,
@@ -106,7 +106,7 @@ func (p *Package) processCgo(filename string, f *ast.File) error {
 		// source location.
 		info.importCPos = spec.Path.ValuePos
 
-		err = info.parseFragment(cgoComment + cgoTypes)
+		err = info.parseFragment(cgoComment+cgoTypes, cflags)
 		if err != nil {
 			return err
 		}

--- a/loader/errors.go
+++ b/loader/errors.go
@@ -1,0 +1,27 @@
+package loader
+
+// Errors contains a list of parser errors or a list of typechecker errors for
+// the given package.
+type Errors struct {
+	Pkg  *Package
+	Errs []error
+}
+
+func (e Errors) Error() string {
+	return "could not compile: " + e.Errs[0].Error()
+}
+
+// ImportCycleErrors is returned when encountering an import cycle. The list of
+// packages is a list from the root package to the leaf package that imports one
+// of the packages in the list.
+type ImportCycleError struct {
+	Packages []string
+}
+
+func (e *ImportCycleError) Error() string {
+	msg := "import cycle: " + e.Packages[0]
+	for _, path := range e.Packages[1:] {
+		msg += " → " + path
+	}
+	return msg
+}

--- a/loader/libclang-cfuncs.go
+++ b/loader/libclang-cfuncs.go
@@ -1,0 +1,12 @@
+package loader
+
+/*
+#include <clang-c/Index.h> // if this fails, install libclang-7-dev
+
+// The gateway function
+int tinygo_clang_visitor_cgo(CXCursor c, CXCursor parent, CXClientData client_data) {
+	int tinygo_clang_visitor(CXCursor c, CXCursor parent, CXClientData client_data);
+	return tinygo_clang_visitor(c, parent, client_data);
+}
+*/
+import "C"

--- a/loader/libclang.go
+++ b/loader/libclang.go
@@ -93,6 +93,17 @@ func tinygo_clang_visitor(c, parent C.CXCursor, client_data C.CXClientData) C.in
 		resultType := C.clang_getCursorResultType(c)
 		resultTypeName := getString(C.clang_getTypeSpelling(resultType))
 		fn.result = resultTypeName
+	case C.CXCursor_TypedefDecl:
+		typedefType := C.clang_getCursorType(c)
+		name := getString(C.clang_getTypedefName(typedefType))
+		underlyingType := C.clang_getTypedefDeclUnderlyingType(c)
+		underlyingTypeName := getString(C.clang_getTypeSpelling(underlyingType))
+		typeSize := C.clang_Type_getSizeOf(underlyingType)
+		info.typedefs = append(info.typedefs, &typedefInfo{
+			newName: name,
+			oldName: underlyingTypeName,
+			size:    int(typeSize),
+		})
 	}
 	return C.CXChildVisit_Continue
 }

--- a/loader/libclang.go
+++ b/loader/libclang.go
@@ -1,0 +1,105 @@
+package loader
+
+// This file parses a fragment of C with libclang and stores the result for AST
+// modification. It does not touch the AST itself.
+
+import (
+	"errors"
+	"unsafe"
+)
+
+/*
+#cgo CFLAGS: -I/usr/lib/llvm-7/include
+#cgo LDFLAGS: -L/usr/lib/llvm-7/lib -lclang
+#include <clang-c/Index.h> // if this fails, install libclang-7-dev
+#include <stdlib.h>
+
+int tinygo_clang_visitor_cgo(CXCursor c, CXCursor parent, CXClientData client_data);
+*/
+import "C"
+
+var globalFileInfo *fileInfo
+
+func (info *fileInfo) parseFragment(fragment string) error {
+	index := C.clang_createIndex(0, 1)
+	defer C.clang_disposeIndex(index)
+
+	filenameC := C.CString("cgo-fake.c")
+	defer C.free(unsafe.Pointer(filenameC))
+
+	fragmentC := C.CString(fragment)
+	defer C.free(unsafe.Pointer(fragmentC))
+
+	unsavedFile := C.struct_CXUnsavedFile{
+		Filename: filenameC,
+		Length:   C.ulong(len(fragment)),
+		Contents: fragmentC,
+	}
+
+	var unit C.CXTranslationUnit
+	errCode := C.clang_parseTranslationUnit2(
+		index,
+		filenameC,
+		(**C.char)(unsafe.Pointer(uintptr(0))), 0, // command line args
+		&unsavedFile, 1, // unsaved files
+		C.CXTranslationUnit_None,
+		&unit)
+	if errCode != 0 {
+		panic("loader: failed to parse source with libclang")
+	}
+	defer C.clang_disposeTranslationUnit(unit)
+
+	if C.clang_getNumDiagnostics(unit) != 0 {
+		return errors.New("cgo: libclang cannot parse fragment")
+	}
+
+	if globalFileInfo != nil {
+		// There is a race condition here but that doesn't really matter as it
+		// is a sanity check anyway.
+		panic("libclang.go cannot be used concurrently yet")
+	}
+	globalFileInfo = info
+	defer func() {
+		globalFileInfo = nil
+	}()
+
+	cursor := C.clang_getTranslationUnitCursor(unit)
+	C.clang_visitChildren(cursor, (*[0]byte)((unsafe.Pointer(C.tinygo_clang_visitor_cgo))), C.CXClientData(uintptr(0)))
+
+	return nil
+}
+
+//export tinygo_clang_visitor
+func tinygo_clang_visitor(c, parent C.CXCursor, client_data C.CXClientData) C.int {
+	info := globalFileInfo
+	kind := C.clang_getCursorKind(c)
+	switch kind {
+	case C.CXCursor_FunctionDecl:
+		name := getString(C.clang_getCursorSpelling(c))
+		cursorType := C.clang_getCursorType(c)
+		if C.clang_isFunctionTypeVariadic(cursorType) != 0 {
+			return C.CXChildVisit_Continue // not supported
+		}
+		numArgs := C.clang_Cursor_getNumArguments(c)
+		fn := &functionInfo{name: name}
+		info.functions = append(info.functions, fn)
+		for i := C.int(0); i < numArgs; i++ {
+			arg := C.clang_Cursor_getArgument(c, C.uint(i))
+			argName := getString(C.clang_getCursorSpelling(arg))
+			argType := C.clang_getArgType(cursorType, C.uint(i))
+			argTypeName := getString(C.clang_getTypeSpelling(argType))
+			fn.args = append(fn.args, paramInfo{argName, argTypeName})
+		}
+		resultType := C.clang_getCursorResultType(c)
+		resultTypeName := getString(C.clang_getTypeSpelling(resultType))
+		fn.result = resultTypeName
+	}
+	return C.CXChildVisit_Continue
+}
+
+func getString(clangString C.CXString) (s string) {
+	rawString := C.clang_getCString(clangString)
+	s = C.GoString(rawString)
+	C.clang_disposeString(clangString)
+	return
+}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -1,0 +1,333 @@
+package loader
+
+import (
+	"errors"
+	"go/ast"
+	"go/build"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// Program holds all packages and some metadata about the program as a whole.
+type Program struct {
+	Build       *build.Context
+	Packages    map[string]*Package
+	sorted      []*Package
+	fset        *token.FileSet
+	TypeChecker types.Config
+	Dir         string // current working directory (for error reporting)
+}
+
+// Package holds a loaded package, its imports, and its parsed files.
+type Package struct {
+	*Program
+	*build.Package
+	Imports   map[string]*Package
+	Importing bool
+	Files     []*ast.File
+	Pkg       *types.Package
+	types.Info
+}
+
+// Import loads the given package relative to srcDir (for the vendor directory).
+// It only loads the current package without recursion.
+func (p *Program) Import(path, srcDir string) (*Package, error) {
+	if p.Packages == nil {
+		p.Packages = make(map[string]*Package)
+	}
+
+	// Load this package.
+	buildPkg, err := p.Build.Import(path, srcDir, build.ImportComment)
+	if err != nil {
+		return nil, err
+	}
+	if existingPkg, ok := p.Packages[buildPkg.ImportPath]; ok {
+		// Already imported, or at least started the import.
+		return existingPkg, nil
+	}
+	p.sorted = nil // invalidate the sorted order of packages
+	pkg := p.newPackage(buildPkg)
+	p.Packages[buildPkg.ImportPath] = pkg
+	return pkg, nil
+}
+
+// ImportFile loads and parses the import statements in the given path and
+// creates a pseudo-package out of it.
+func (p *Program) ImportFile(path string) (*Package, error) {
+	if p.Packages == nil {
+		p.Packages = make(map[string]*Package)
+	}
+	if _, ok := p.Packages[path]; ok {
+		// unlikely
+		return nil, errors.New("loader: cannot import file that is already imported as package: " + path)
+	}
+
+	file, err := p.parseFile(path, parser.ImportsOnly)
+	if err != nil {
+		return nil, err
+	}
+	buildPkg := &build.Package{
+		Dir:        filepath.Dir(path),
+		ImportPath: path,
+		GoFiles:    []string{filepath.Base(path)},
+	}
+	for _, importSpec := range file.Imports {
+		buildPkg.Imports = append(buildPkg.Imports, importSpec.Path.Value[1:len(importSpec.Path.Value)-1])
+	}
+	p.sorted = nil // invalidate the sorted order of packages
+	pkg := p.newPackage(buildPkg)
+	p.Packages[buildPkg.ImportPath] = pkg
+	return pkg, nil
+}
+
+// newPackage instantiates a new *Package object with initialized members.
+func (p *Program) newPackage(pkg *build.Package) *Package {
+	return &Package{
+		Program: p,
+		Package: pkg,
+		Imports: make(map[string]*Package, len(pkg.Imports)),
+		Info: types.Info{
+			Types:      make(map[ast.Expr]types.TypeAndValue),
+			Defs:       make(map[*ast.Ident]types.Object),
+			Uses:       make(map[*ast.Ident]types.Object),
+			Implicits:  make(map[ast.Node]types.Object),
+			Scopes:     make(map[ast.Node]*types.Scope),
+			Selections: make(map[*ast.SelectorExpr]*types.Selection),
+		},
+	}
+}
+
+// Sorted returns a list of all packages, sorted in a way that no packages come
+// before the packages they depend upon.
+func (p *Program) Sorted() []*Package {
+	if p.sorted == nil {
+		p.sort()
+	}
+	return p.sorted
+}
+
+func (p *Program) sort() {
+	p.sorted = nil
+	packageList := make([]*Package, 0, len(p.Packages))
+	packageSet := make(map[string]struct{}, len(p.Packages))
+	worklist := make([]string, 0, len(p.Packages))
+	for path := range p.Packages {
+		worklist = append(worklist, path)
+	}
+	sort.Strings(worklist)
+	for len(worklist) != 0 {
+		pkgPath := worklist[0]
+		pkg := p.Packages[pkgPath]
+
+		if _, ok := packageSet[pkgPath]; ok {
+			// Package already in the final package list.
+			worklist = worklist[1:]
+			continue
+		}
+
+		unsatisfiedImports := make([]string, 0)
+		for _, pkg := range pkg.Imports {
+			if _, ok := packageSet[pkg.ImportPath]; ok {
+				continue
+			}
+			unsatisfiedImports = append(unsatisfiedImports, pkg.ImportPath)
+		}
+		sort.Strings(unsatisfiedImports)
+		if len(unsatisfiedImports) == 0 {
+			// All dependencies of this package are satisfied, so add this
+			// package to the list.
+			packageList = append(packageList, pkg)
+			packageSet[pkgPath] = struct{}{}
+			worklist = worklist[1:]
+		} else {
+			// Prepend all dependencies to the worklist and reconsider this
+			// package (by not removing it from the worklist). At that point, it
+			// must be possible to add it to packageList.
+			worklist = append(unsatisfiedImports, worklist...)
+		}
+	}
+
+	p.sorted = packageList
+}
+
+// Parse recursively imports all packages, parses them, and typechecks them.
+//
+// The returned error may be an Errors error, which contains a list of errors.
+//
+// Idempotent.
+func (p *Program) Parse() error {
+	// Load all imports
+	for _, pkg := range p.Sorted() {
+		err := pkg.importRecursively()
+		if err != nil {
+			if err, ok := err.(*ImportCycleError); ok {
+				err.Packages = append([]string{pkg.ImportPath}, err.Packages...)
+			}
+			return err
+		}
+	}
+
+	// Parse all packages.
+	for _, pkg := range p.Sorted() {
+		err := pkg.Parse()
+		if err != nil {
+			return err
+		}
+	}
+
+	// Typecheck all packages.
+	for _, pkg := range p.Sorted() {
+		err := pkg.Check()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// parseFile is a wrapper around parser.ParseFile.
+func (p *Program) parseFile(path string, mode parser.Mode) (*ast.File, error) {
+	if p.fset == nil {
+		p.fset = token.NewFileSet()
+	}
+
+	rd, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer rd.Close()
+	relpath := path
+	if filepath.IsAbs(path) {
+		relpath, err = filepath.Rel(p.Dir, path)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return parser.ParseFile(p.fset, relpath, rd, mode)
+}
+
+// Parse parses and typechecks this package.
+//
+// Idempotent.
+func (p *Package) Parse() error {
+	if len(p.Files) != 0 {
+		return nil
+	}
+
+	// Load the AST.
+	// TODO: do this in parallel.
+	if p.ImportPath == "unsafe" {
+		// Special case for the unsafe package. Don't even bother loading
+		// the files.
+		p.Pkg = types.Unsafe
+		return nil
+	}
+
+	files, err := p.parseFiles()
+	if err != nil {
+		return err
+	}
+	p.Files = files
+
+	return nil
+}
+
+// Check runs the package through the typechecker. The package must already be
+// loaded and all dependencies must have been checked already.
+//
+// Idempotent.
+func (p *Package) Check() error {
+	if p.Pkg != nil {
+		return nil
+	}
+
+	var typeErrors []error
+	checker := p.TypeChecker
+	checker.Error = func(err error) {
+		typeErrors = append(typeErrors, err)
+	}
+
+	// Do typechecking of the package.
+	checker.Importer = p
+
+	typesPkg, err := checker.Check(p.ImportPath, p.fset, p.Files, &p.Info)
+	if err != nil {
+		if err, ok := err.(Errors); ok {
+			return err
+		}
+		return Errors{p, typeErrors}
+	}
+	p.Pkg = typesPkg
+	return nil
+}
+
+// parseFiles parses the loaded list of files and returns this list.
+func (p *Package) parseFiles() ([]*ast.File, error) {
+	if len(p.CgoFiles) != 0 {
+		return nil, errors.New("loader: todo cgo: " + p.CgoFiles[0])
+	}
+
+	// TODO: do this concurrently.
+	var files []*ast.File
+	var fileErrs []error
+	for _, file := range p.GoFiles {
+		f, err := p.parseFile(filepath.Join(p.Package.Dir, file), parser.ParseComments)
+		if err != nil {
+			fileErrs = append(fileErrs, err)
+		} else {
+			files = append(files, f)
+		}
+	}
+	if len(fileErrs) != 0 {
+		return nil, Errors{p, fileErrs}
+	}
+	return files, nil
+}
+
+// Import implements types.Importer. It loads and parses packages it encounters
+// along the way, if needed.
+func (p *Package) Import(to string) (*types.Package, error) {
+	if to == "unsafe" {
+		return types.Unsafe, nil
+	}
+	if _, ok := p.Imports[to]; ok {
+		return p.Imports[to].Pkg, nil
+	} else {
+		panic("package not imported: " + to)
+	}
+}
+
+// importRecursively calls Program.Import() on all imported packages, and calls
+// importRecursively() on the imported packages as well.
+//
+// Idempotent.
+func (p *Package) importRecursively() error {
+	p.Importing = true
+	for _, to := range p.Package.Imports {
+		if _, ok := p.Imports[to]; ok {
+			continue
+		}
+		importedPkg, err := p.Program.Import(to, p.Package.Dir)
+		if err != nil {
+			if err, ok := err.(*ImportCycleError); ok {
+				err.Packages = append([]string{p.ImportPath}, err.Packages...)
+			}
+			return err
+		}
+		if importedPkg.Importing {
+			return &ImportCycleError{[]string{p.ImportPath, importedPkg.ImportPath}}
+		}
+		err = importedPkg.importRecursively()
+		if err != nil {
+			return err
+		}
+		p.Imports[to] = importedPkg
+	}
+	p.Importing = false
+	return nil
+}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -20,6 +20,7 @@ type Program struct {
 	fset        *token.FileSet
 	TypeChecker types.Config
 	Dir         string // current working directory (for error reporting)
+	CFlags      []string
 }
 
 // Package holds a loaded package, its imports, and its parsed files.
@@ -290,7 +291,7 @@ func (p *Package) parseFiles() ([]*ast.File, error) {
 			fileErrs = append(fileErrs, err)
 			continue
 		}
-		err = p.processCgo(path, f)
+		err = p.processCgo(path, f, append(p.CFlags, "-I"+p.Package.Dir))
 		if err != nil {
 			fileErrs = append(fileErrs, err)
 			continue

--- a/loader/ssa.go
+++ b/loader/ssa.go
@@ -1,0 +1,18 @@
+package loader
+
+import (
+	"golang.org/x/tools/go/ssa"
+)
+
+// LoadSSA constructs the SSA form of the loaded packages.
+//
+// The program must already be parsed and type-checked with the .Parse() method.
+func (p *Program) LoadSSA() *ssa.Program {
+	prog := ssa.NewProgram(p.fset, ssa.SanityCheckFunctions|ssa.BareInits|ssa.GlobalDebug)
+
+	for _, pkg := range p.Sorted() {
+		prog.CreatePackage(pkg.Pkg, pkg.Files, &pkg.Info, true)
+	}
+
+	return prog
+}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aykevl/go-llvm"
 	"github.com/aykevl/tinygo/compiler"
 	"github.com/aykevl/tinygo/interp"
+	"github.com/aykevl/tinygo/loader"
 )
 
 var commands = map[string]string{
@@ -454,6 +455,11 @@ func handleCompilerError(err error) {
 			fmt.Fprintln(os.Stderr)
 		} else if errCompiler, ok := err.(types.Error); ok {
 			fmt.Fprintln(os.Stderr, errCompiler)
+		} else if errLoader, ok := err.(loader.Errors); ok {
+			fmt.Fprintln(os.Stderr, "#", errLoader.Pkg.ImportPath)
+			for _, err := range errLoader.Errs {
+				fmt.Fprintln(os.Stderr, err)
+			}
 		} else {
 			fmt.Fprintln(os.Stderr, "error:", err)
 		}

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 	compilerConfig := compiler.Config{
 		Triple:     spec.Triple,
 		GC:         config.gc,
+		CFlags:     spec.CFlags,
 		Debug:      config.debug,
 		DumpSSA:    config.dumpSSA,
 		RootDir:    sourceDir(),

--- a/target.go
+++ b/target.go
@@ -155,6 +155,7 @@ func LoadTarget(target string) (*TargetSpec, error) {
 		*spec = TargetSpec{
 			Triple:    target,
 			BuildTags: []string{runtime.GOOS, runtime.GOARCH},
+			Compiler:  commands["clang"],
 			Linker:    "cc",
 			LDFlags:   []string{"-no-pie"}, // WARNING: clang < 5.0 requires -nopie
 			Objcopy:   "objcopy",

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -1,7 +1,12 @@
 {
 	"llvm-target":   "wasm32-unknown-unknown-wasm",
 	"build-tags":    ["js", "wasm"],
+	"compiler":      "clang-7",
 	"linker":        "ld.lld-7",
+	"cflags": [
+		"--target=wasm32",
+		"-Oz"
+	],
 	"ldflags": [
 		"-flavor", "wasm",
 		"-allow-undefined"

--- a/testdata/cgo/main.c
+++ b/testdata/cgo/main.c
@@ -1,3 +1,5 @@
+#include "main.h"
+
 int fortytwo() {
 	return 42;
 }

--- a/testdata/cgo/main.c
+++ b/testdata/cgo/main.c
@@ -4,6 +4,10 @@ int32_t fortytwo() {
 	return 42;
 }
 
+int add(int a, int b) {
+	return a + b;
+}
+
 int32_t mul(int32_t a, int32_t b) {
 	return a * b;
 }

--- a/testdata/cgo/main.c
+++ b/testdata/cgo/main.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+
+int32_t fortytwo() {
+	return 42;
+}
+
+int32_t mul(int32_t a, int32_t b) {
+	return a * b;
+}

--- a/testdata/cgo/main.c
+++ b/testdata/cgo/main.c
@@ -1,13 +1,7 @@
-#include <stdint.h>
-
-int32_t fortytwo() {
+int fortytwo() {
 	return 42;
 }
 
 int add(int a, int b) {
 	return a + b;
-}
-
-int32_t mul(int32_t a, int32_t b) {
-	return a * b;
 }

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -1,0 +1,13 @@
+package main
+
+/*
+#include <stdint.h>
+int32_t fortytwo(void);
+int32_t mul(int32_t a, int32_t b);
+*/
+import "C"
+
+func main() {
+	println("fortytwo:", C.fortytwo())
+	println("mul:", C.mul(int32(3), 5))
+}

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -1,20 +1,20 @@
 package main
 
 /*
-#include <stdint.h>
-int32_t fortytwo(void);
-int32_t mul(int32_t a, int32_t b);
-typedef int32_t myint;
+int fortytwo(void);
+typedef short myint;
 int add(int a, int b);
 */
 import "C"
 
+import "unsafe"
+
 func main() {
 	println("fortytwo:", C.fortytwo())
-	println("mul:", C.mul(C.int32_t(3), 5))
 	println("add:", C.add(C.int(3), 5))
 	var x C.myint = 3
 	println("myint:", x, C.myint(5))
+	println("myint size:", int(unsafe.Sizeof(x)))
 	var y C.longlong = -(1 << 40)
 	println("longlong:", y)
 }

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -5,12 +5,16 @@ package main
 int32_t fortytwo(void);
 int32_t mul(int32_t a, int32_t b);
 typedef int32_t myint;
+int add(int a, int b);
 */
 import "C"
 
 func main() {
 	println("fortytwo:", C.fortytwo())
 	println("mul:", C.mul(C.int32_t(3), 5))
+	println("add:", C.add(C.int(3), 5))
 	var x C.myint = 3
 	println("myint:", x, C.myint(5))
+	var y C.longlong = -(1 << 40)
+	println("longlong:", y)
 }

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -4,10 +4,13 @@ package main
 #include <stdint.h>
 int32_t fortytwo(void);
 int32_t mul(int32_t a, int32_t b);
+typedef int32_t myint;
 */
 import "C"
 
 func main() {
 	println("fortytwo:", C.fortytwo())
-	println("mul:", C.mul(int32(3), 5))
+	println("mul:", C.mul(C.int32_t(3), 5))
+	var x C.myint = 3
+	println("myint:", x, C.myint(5))
 }

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -2,8 +2,7 @@ package main
 
 /*
 int fortytwo(void);
-typedef short myint;
-int add(int a, int b);
+#include "main.h"
 */
 import "C"
 

--- a/testdata/cgo/main.h
+++ b/testdata/cgo/main.h
@@ -1,0 +1,2 @@
+typedef short myint;
+int add(int a, int b);

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -1,2 +1,3 @@
 fortytwo: 42
 mul: 15
+myint: 3 5

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -1,5 +1,5 @@
 fortytwo: 42
-mul: 15
 add: 8
 myint: 3 5
+myint size: 2
 longlong: -1099511627776

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -1,0 +1,2 @@
+fortytwo: 42
+mul: 15

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -1,3 +1,5 @@
 fortytwo: 42
 mul: 15
+add: 8
 myint: 3 5
+longlong: -1099511627776


### PR DESCRIPTION
We were using `golang.org/x/tools/go/loader`, but there are lots of limitations with that for TinyGo. One in particular is that it is not possible to get loaded .c files (etc.) to be include with the program. Also, it looks like `golang.org/x/tools/go/loader` is being deprecated in favor of `golang.org/x/tools/go/packages`, which has even more problems.

By using our own loader, it is possible to support more advanced features in the future like special import paths and doing incremental compilation by loading type information from existing object files. Right now it makes it possible to write our own Cgo implementation.