### PR TITLE
Add WIP on support for this nrf52840-based board

### DIFF
--- a/src/machine/board_pca10056.go
+++ b/src/machine/board_pca10056.go
@@ -1,0 +1,35 @@
+// +build pca10056
+
+package machine
+
+const HasLowFrequencyCrystal = true
+
+// LEDs on the pca10056
+const (
+	LED  = LED1
+	LED1 = 13
+	LED2 = 14
+	LED3 = 15
+	LED4 = 16
+)
+
+// Buttons on the pca10056
+const (
+	BUTTON  = BUTTON1
+	BUTTON1 = 11
+	BUTTON2 = 12
+	BUTTON3 = 24
+	BUTTON4 = 25
+)
+
+// UART pins
+const (
+	UART_TX_PIN = 6
+	UART_RX_PIN = 8
+)
+
+// I2C pins
+const (
+	SDA_PIN = 26
+	SCL_PIN = 27
+)

--- a/targets/pca10056.json
+++ b/targets/pca10056.json
@@ -1,0 +1,7 @@
+{
+	"inherits": ["nrf52840"],
+	"build-tags": ["pca10056"],
+	"flash": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
+	"ocd-daemon": ["openocd", "-f", "interface/cmsis-dap.cfg", "-f", "target/nrf51.cfg"],
+	"gdb-initial-cmds": ["target remote :3333", "monitor halt", "load", "monitor reset", "c"]
+}


### PR DESCRIPTION
Add device support for the pca10056, which is the nrf52840 developer kit board.

https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.nrf52%2Fdita%2Fnrf52%2Fdevelopment%2Fnrf52840_pdk%2Fintro.html