### PR TITLE
all: add stub pieces for GoLand support

### DIFF
--- a/src/runtime/internal/sys/zversion.go
+++ b/src/runtime/internal/sys/zversion.go
@@ -1,0 +1,1 @@
+TheVersion = `go0.1.0`


### PR DESCRIPTION
The bin/.keep file is just to ensure the bin directory is present, whereas the zversion.go file is read by GoLand as part of determining whether the repo is a valid Go SDK.