### PR TITLE
Add SPI support for all NRF-based boards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TARGET ?= unix
 ifeq ($(TARGET),unix)
 # Regular *nix system.
 
-else ifeq ($(TARGET),pca10040)
+else ifeq ($(TARGET),pca10056)
 # PCA10040: nRF52832 development board
 OBJCOPY = arm-none-eabi-objcopy
 TGOFLAGS += -target $(TARGET)
@@ -49,7 +49,7 @@ run-blinky: run-blinky2
 run-blinky2: build/blinky2
 	./build/blinky2
 
-ifeq ($(TARGET),pca10040)
+ifeq ($(TARGET),pca10056)
 flash-%: build/%.hex
 	nrfjprog -f nrf52 --sectorerase --program $< --reset
 else ifeq ($(TARGET),microbit)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TARGET ?= unix
 ifeq ($(TARGET),unix)
 # Regular *nix system.
 
-else ifeq ($(TARGET),pca10056)
+else ifeq ($(TARGET),pca10040)
 # PCA10040: nRF52832 development board
 OBJCOPY = arm-none-eabi-objcopy
 TGOFLAGS += -target $(TARGET)
@@ -49,7 +49,7 @@ run-blinky: run-blinky2
 run-blinky2: build/blinky2
 	./build/blinky2
 
-ifeq ($(TARGET),pca10056)
+ifeq ($(TARGET),pca10040)
 flash-%: build/%.hex
 	nrfjprog -f nrf52 --sectorerase --program $< --reset
 else ifeq ($(TARGET),microbit)

--- a/src/machine/board_microbit.go
+++ b/src/machine/board_microbit.go
@@ -36,6 +36,13 @@ const (
 	SCL_PIN = 0  // P19 on the board
 )
 
+// SPI pins
+const (
+	SPI0_SCK_PIN  = 0
+	SPI0_MOSI_PIN = 0
+	SPI0_MISO_PIN = 0
+)
+
 // LED matrix pins
 const (
 	LED_COL_1 = 4

--- a/src/machine/board_nrf52840-mdk.go
+++ b/src/machine/board_nrf52840-mdk.go
@@ -23,3 +23,10 @@ const (
 	SDA_PIN = 0xff
 	SCL_PIN = 0xff
 )
+
+// SPI pins (unused)
+const (
+	SPI0_SCK_PIN  = 0
+	SPI0_MOSI_PIN = 0
+	SPI0_MISO_PIN = 0
+)

--- a/src/machine/board_pca10031.go
+++ b/src/machine/board_pca10031.go
@@ -30,3 +30,10 @@ const (
 	SDA_PIN = 0xff
 	SCL_PIN = 0xff
 )
+
+// SPI pins (unused)
+const (
+	SPI0_SCK_PIN  = 0
+	SPI0_MOSI_PIN = 0
+	SPI0_MISO_PIN = 0
+)

--- a/src/machine/board_pca10040.go
+++ b/src/machine/board_pca10040.go
@@ -44,3 +44,14 @@ const (
 	SDA_PIN = 26
 	SCL_PIN = 27
 )
+
+// SPI pins
+const (
+	SPI0_SCK_PIN  = 25
+	SPI0_MOSI_PIN = 23
+	SPI0_MISO_PIN = 24
+
+	SPI1_SCK_PIN  = 2
+	SPI1_MOSI_PIN = 3
+	SPI1_MISO_PIN = 4
+)

--- a/src/machine/board_pca10056.go
+++ b/src/machine/board_pca10056.go
@@ -30,6 +30,13 @@ const (
 
 // I2C pins
 const (
-	SDA_PIN = 26
-	SCL_PIN = 27
+	SDA_PIN = 26 // P0.26
+	SCL_PIN = 27 // P0.27
+)
+
+// SPI pins
+const (
+	SPI0_SCK_PIN  = 47 // P1.15
+	SPI0_MOSI_PIN = 45 // P1.13
+	SPI0_MISO_PIN = 46 // P1.14
 )

--- a/src/machine/board_reelboard.go
+++ b/src/machine/board_reelboard.go
@@ -33,3 +33,10 @@ const (
 	SDA_PIN = 26
 	SCL_PIN = 27
 )
+
+// SPI pins
+const (
+	SPI0_SCK_PIN  = 47
+	SPI0_MOSI_PIN = 45
+	SPI0_MISO_PIN = 46
+)

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -5,7 +5,6 @@ package machine
 import (
 	"device/arm"
 	"device/nrf"
-	"errors"
 )
 
 type GPIOMode uint8
@@ -317,22 +316,8 @@ func (spi SPI) Configure(config SPIConfig) {
 	spi.Bus.ENABLE = nrf.SPI_ENABLE_ENABLE_Enabled
 }
 
-// Tx handles read/write operation for SPI interface.
-func (spi SPI) Tx(w, r []byte) error {
-	if len(w) != len(r) {
-		return errors.New("SPI write and read slices must be same size")
-	}
-
-	for i, b := range w {
-		r[i], _ = spi.transferByte(b)
-	}
-
-	// TODO: handle SPI errors
-	return nil
-}
-
-// transferByte writes/reads a single byte using the SPI interface.
-func (spi SPI) transferByte(w byte) (byte, error) {
+// Transfer writes/reads a single byte using the SPI interface.
+func (spi SPI) Transfer(w byte) (byte, error) {
 	spi.Bus.TXD = nrf.RegValue(w)
 	for spi.Bus.EVENTS_READY == 0 {
 	}

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -279,26 +279,34 @@ func (spi SPI) Configure(config SPIConfig) {
 	case 8000000:
 		freq = nrf.SPI_FREQUENCY_FREQUENCY_M8
 	default:
-		freq = nrf.SPI_FREQUENCY_FREQUENCY_K125
+		freq = nrf.SPI_FREQUENCY_FREQUENCY_K500
 	}
 	spi.Bus.FREQUENCY = nrf.RegValue(freq)
 
-	// default to MSB and Mode0
-	conf := nrf.SPI_CONFIG_ORDER_MsbFirst | nrf.SPI_CONFIG_CPOL_ActiveHigh | nrf.SPI_CONFIG_CPHA_Leading
+	var conf uint32
 
 	// set bit transfer order
 	if config.LSBFirst {
-		conf |= nrf.SPI_CONFIG_ORDER_LsbFirst
+		conf = (nrf.SPI_CONFIG_ORDER_LsbFirst << nrf.SPI_CONFIG_ORDER_Pos)
 	}
 
 	// set mode
 	switch config.Mode {
+	case 0:
+		conf &^= (nrf.SPI_CONFIG_CPOL_ActiveHigh << nrf.SPI_CONFIG_CPOL_Pos)
+		conf &^= (nrf.SPI_CONFIG_CPHA_Leading << nrf.SPI_CONFIG_CPHA_Pos)
 	case 1:
-		conf |= (nrf.SPI_CONFIG_CPOL_ActiveHigh | nrf.SPI_CONFIG_CPHA_Trailing)
+		conf &^= (nrf.SPI_CONFIG_CPOL_ActiveHigh << nrf.SPI_CONFIG_CPOL_Pos)
+		conf |= (nrf.SPI_CONFIG_CPHA_Trailing << nrf.SPI_CONFIG_CPHA_Pos)
 	case 2:
-		conf |= (nrf.SPI_CONFIG_CPOL_ActiveLow | nrf.SPI_CONFIG_CPHA_Leading)
+		conf |= (nrf.SPI_CONFIG_CPOL_ActiveLow << nrf.SPI_CONFIG_CPOL_Pos)
+		conf &^= (nrf.SPI_CONFIG_CPHA_Leading << nrf.SPI_CONFIG_CPHA_Pos)
 	case 3:
-		conf |= (nrf.SPI_CONFIG_CPOL_ActiveLow | nrf.SPI_CONFIG_CPHA_Trailing)
+		conf |= (nrf.SPI_CONFIG_CPOL_ActiveLow << nrf.SPI_CONFIG_CPOL_Pos)
+		conf |= (nrf.SPI_CONFIG_CPHA_Trailing << nrf.SPI_CONFIG_CPHA_Pos)
+	default: // to mode
+		conf &^= (nrf.SPI_CONFIG_CPOL_ActiveHigh << nrf.SPI_CONFIG_CPOL_Pos)
+		conf &^= (nrf.SPI_CONFIG_CPHA_Leading << nrf.SPI_CONFIG_CPHA_Pos)
 	}
 	spi.Bus.CONFIG = nrf.RegValue(conf)
 

--- a/src/machine/machine_nrf51.go
+++ b/src/machine/machine_nrf51.go
@@ -28,7 +28,17 @@ func (i2c I2C) setPins(scl, sda uint8) {
 
 // SPI
 func (spi SPI) setPins(sck, mosi, miso uint8) {
-	spi.Bus.PSELSCK = nrf.RegValue(sck)
-	spi.Bus.PSELMOSI = nrf.RegValue(mosi)
-	spi.Bus.PSELMISO = nrf.RegValue(miso)
+	var s, mo, mi = sck, mosi, miso
+	if s == 0 {
+		s = SPI0_SCK_PIN
+	}
+	if mo == 0 {
+		mo = SPI0_MOSI_PIN
+	}
+	if mi == 0 {
+		mi = SPI0_MISO_PIN
+	}
+	spi.Bus.PSELSCK = nrf.RegValue(s)
+	spi.Bus.PSELMOSI = nrf.RegValue(mo)
+	spi.Bus.PSELMISO = nrf.RegValue(mi)
 }

--- a/src/machine/machine_nrf51.go
+++ b/src/machine/machine_nrf51.go
@@ -25,3 +25,10 @@ func (i2c I2C) setPins(scl, sda uint8) {
 	i2c.Bus.PSELSCL = nrf.RegValue(scl)
 	i2c.Bus.PSELSDA = nrf.RegValue(sda)
 }
+
+// SPI
+func (spi SPI) setPins(sck, mosi, miso uint8) {
+	spi.Bus.PSELSCK = nrf.RegValue(sck)
+	spi.Bus.PSELMOSI = nrf.RegValue(mosi)
+	spi.Bus.PSELMISO = nrf.RegValue(miso)
+}

--- a/src/machine/machine_nrf52.go
+++ b/src/machine/machine_nrf52.go
@@ -27,6 +27,13 @@ func (i2c I2C) setPins(scl, sda uint8) {
 	i2c.Bus.PSELSDA = nrf.RegValue(sda)
 }
 
+// SPI
+func (spi SPI) setPins(sck, mosi, miso uint8) {
+	spi.Bus.PSEL.SCK = nrf.RegValue(sck)
+	spi.Bus.PSEL.MOSI = nrf.RegValue(mosi)
+	spi.Bus.PSEL.MISO = nrf.RegValue(miso)
+}
+
 // InitADC initializes the registers needed for ADC.
 func InitADC() {
 	return // no specific setup on nrf52 machine.

--- a/src/machine/machine_nrf52.go
+++ b/src/machine/machine_nrf52.go
@@ -29,9 +29,19 @@ func (i2c I2C) setPins(scl, sda uint8) {
 
 // SPI
 func (spi SPI) setPins(sck, mosi, miso uint8) {
-	spi.Bus.PSEL.SCK = nrf.RegValue(sck)
-	spi.Bus.PSEL.MOSI = nrf.RegValue(mosi)
-	spi.Bus.PSEL.MISO = nrf.RegValue(miso)
+	var s, mo, mi = sck, mosi, miso
+	if s == 0 {
+		s = SPI0_SCK_PIN
+	}
+	if mo == 0 {
+		mo = SPI0_MOSI_PIN
+	}
+	if mi == 0 {
+		mi = SPI0_MISO_PIN
+	}
+	spi.Bus.PSEL.SCK = nrf.RegValue(s)
+	spi.Bus.PSEL.MOSI = nrf.RegValue(mo)
+	spi.Bus.PSEL.MISO = nrf.RegValue(mi)
 }
 
 // InitADC initializes the registers needed for ADC.

--- a/src/machine/machine_nrf52840.go
+++ b/src/machine/machine_nrf52840.go
@@ -29,3 +29,20 @@ func (i2c I2C) setPins(scl, sda uint8) {
 	i2c.Bus.PSEL.SCL = nrf.RegValue(scl)
 	i2c.Bus.PSEL.SDA = nrf.RegValue(sda)
 }
+
+// SPI
+func (spi SPI) setPins(sck, mosi, miso uint8) {
+	var s, mo, mi = sck, mosi, miso
+	if s == 0 {
+		s = SPI0_SCK_PIN
+	}
+	if mo == 0 {
+		mo = SPI0_MOSI_PIN
+	}
+	if mi == 0 {
+		mi = SPI0_MISO_PIN
+	}
+	spi.Bus.PSEL.SCK = nrf.RegValue(s)
+	spi.Bus.PSEL.MOSI = nrf.RegValue(mo)
+	spi.Bus.PSEL.MISO = nrf.RegValue(mi)
+}

--- a/src/machine/spi.go
+++ b/src/machine/spi.go
@@ -1,0 +1,58 @@
+// +build nrf
+
+package machine
+
+import "errors"
+
+// Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+// interface, there must always be the same number of bytes written as bytes read.
+// The Tx method knows about this, and offers a few different ways of calling it.
+// This form sends the bytes in tx buffer, putting the resulting bytes read into the rx buffer.
+// Note that the tx and rx buffers must be the same size:
+// spi.Tx(tx, rx)
+// This form sends the tx buffer, ignoring the result. Useful for sending "commands" that return zeros
+// until all the bytes in the command packet have been received:
+// spi.Tx(tx, nil)
+// This form sends zeros, putting the result into the rx buffer. Good for reading a "result packet":
+// spi.Tx(nil, rx)
+func (spi SPI) Tx(w, r []byte) error {
+	if w == nil && r == nil {
+		return errors.New("SPI Tx requires a write or read slice, or both")
+	}
+
+	var err error
+
+	switch {
+	case w == nil:
+		// read only, so write zero and read a result.
+		for i := range r {
+			r[i], err = spi.Transfer(0)
+			if err != nil {
+				return err
+			}
+		}
+	case r == nil:
+		// write only
+		for _, b := range w {
+			_, err = spi.Transfer(b)
+			if err != nil {
+				return err
+			}
+		}
+
+	default:
+		// write/read
+		if len(w) != len(r) {
+			return errors.New("SPI write and read slices must be same size")
+		}
+
+		for i, b := range w {
+			r[i], err = spi.Transfer(b)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds SPI hardware support to all current NRF-based boards.

For example, this reads an analog value from an connected MCP3008 ADC:

```go
// Connects to an MCP3008 ADC via SPI.
package main

import (
	"errors"
	"machine"
	"time"
)

var (
	tx          []byte
	rx          []byte
	val, result uint16
	cs          machine.GPIO
)

func main() {
	cs = machine.GPIO{3}
	cs.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})

	machine.SPI0.Configure(machine.SPIConfig{
		Frequency: 4000000,
		Mode:      3})

	tx = make([]byte, 3)
	rx = make([]byte, 3)

	for {
		val, _ = Read(0)
		println(val)
		time.Sleep(50 * time.Millisecond)
	}
}

// Read analog data from channel
func Read(channel int) (uint16, error) {
	if channel < 0 || channel > 7 {
		return 0, errors.New("Invalid channel for read")
	}

	tx[0] = 0x01
	tx[1] = byte(8+channel) << 4
	tx[2] = 0x00

	cs.Low()
	machine.SPI0.Tx(tx, rx)
	result = uint16((rx[1]&0x3))<<8 + uint16(rx[2])
	cs.High()

	return result, nil
}
```
