### PR TITLE
compiler: always use fat function pointers with context

### DIFF
--- a/compiler/calls.go
+++ b/compiler/calls.go
@@ -21,6 +21,9 @@ func (c *Compiler) createRuntimeCall(fnName string, args []llvm.Value, name stri
 		panic("trying to call runtime." + fnName)
 	}
 	fn := c.ir.GetFunction(member.(*ssa.Function))
+	if !fn.IsExported() {
+		args = append(args, llvm.Undef(c.i8ptrType)) // unused context parameter
+	}
 	return c.createCall(fn.LLVMFn, args, name)
 }
 

--- a/compiler/defer.go
+++ b/compiler/defer.go
@@ -1,30 +1,35 @@
 package compiler
 
-// This file implements the 'defer' keyword in Go. See src/runtime/defer.go for
-// details.
+// This file implements the 'defer' keyword in Go.
+// Defer statements are implemented by transforming the function in the
+// following way:
+//   * Creating an alloca in the entry block that contains a pointer (initially
+//     null) to the linked list of defer frames.
+//   * Every time a defer statement is executed, a new defer frame is created
+//     using alloca with a pointer to the previous defer frame, and the head
+//     pointer in the entry block is replaced with a pointer to this defer
+//     frame.
+//   * On return, runtime.rundefers is called which calls all deferred functions
+//     from the head of the linked list until it has gone through all defer
+//     frames.
 
 import (
 	"go/types"
 
 	"github.com/aykevl/go-llvm"
+	"github.com/aykevl/tinygo/ir"
 	"golang.org/x/tools/go/ssa"
 )
 
-// A thunk for a defer that defers calling a function pointer with context.
-type ContextDeferFunction struct {
-	fn          llvm.Value
-	deferStruct []llvm.Type
-	signature   *types.Signature
-}
-
-// A thunk for a defer that defers calling an interface method.
-type InvokeDeferFunction struct {
-	method     *types.Func
-	valueTypes []llvm.Type
-}
-
-// deferInitFunc sets up this function for future deferred calls.
+// deferInitFunc sets up this function for future deferred calls. It must be
+// called from within the entry block when this function contains deferred
+// calls.
 func (c *Compiler) deferInitFunc(frame *Frame) {
+	// Some setup.
+	frame.deferFuncs = make(map[*ir.Function]int)
+	frame.deferInvokeFuncs = make(map[string]int)
+	frame.deferClosureFuncs = make(map[*ir.Function]int)
+
 	// Create defer list pointer.
 	deferType := llvm.PointerType(c.mod.GetTypeByName("runtime._defer"), 0)
 	frame.deferPtr = c.builder.CreateAlloca(deferType, "deferPtr")
@@ -38,57 +43,50 @@ func (c *Compiler) emitDefer(frame *Frame, instr *ssa.Defer) error {
 	// make a linked list.
 	next := c.builder.CreateLoad(frame.deferPtr, "defer.next")
 
-	deferFuncType := llvm.FunctionType(c.ctx.VoidType(), []llvm.Type{next.Type()}, false)
-
 	var values []llvm.Value
-	var valueTypes []llvm.Type
+	valueTypes := []llvm.Type{c.uintptrType, next.Type()}
 	if instr.Call.IsInvoke() {
-		// Function call on an interface.
-		fnPtr, args, err := c.getInvokeCall(frame, &instr.Call)
+		// Method call on an interface.
+
+		// Get callback type number.
+		methodName := instr.Call.Method.FullName()
+		if _, ok := frame.deferInvokeFuncs[methodName]; !ok {
+			frame.deferInvokeFuncs[methodName] = len(frame.allDeferFuncs)
+			frame.allDeferFuncs = append(frame.allDeferFuncs, &instr.Call)
+		}
+		callback := llvm.ConstInt(c.uintptrType, uint64(frame.deferInvokeFuncs[methodName]), false)
+
+		// Collect all values to be put in the struct (starting with
+		// runtime._defer fields, followed by the call parameters).
+		itf, err := c.parseExpr(frame, instr.Call.Value) // interface
 		if err != nil {
 			return err
 		}
-
-		valueTypes = []llvm.Type{llvm.PointerType(deferFuncType, 0), next.Type(), fnPtr.Type()}
-		for _, param := range args {
-			valueTypes = append(valueTypes, param.Type())
-		}
-
-		// Create a thunk.
-		deferName := instr.Call.Method.FullName() + "$defer"
-		callback := c.mod.NamedFunction(deferName)
-		if callback.IsNil() {
-			// Not found, have to add it.
-			callback = llvm.AddFunction(c.mod, deferName, deferFuncType)
-			thunk := InvokeDeferFunction{
-				method:     instr.Call.Method,
-				valueTypes: valueTypes,
+		receiverValue := c.builder.CreateExtractValue(itf, 1, "invoke.func.receiver")
+		values = []llvm.Value{callback, next, receiverValue}
+		valueTypes = append(valueTypes, c.i8ptrType)
+		for _, arg := range instr.Call.Args {
+			val, err := c.parseExpr(frame, arg)
+			if err != nil {
+				return err
 			}
-			c.deferInvokeFuncs = append(c.deferInvokeFuncs, thunk)
+			values = append(values, val)
+			valueTypes = append(valueTypes, val.Type())
 		}
-
-		// Collect all values to be put in the struct (starting with
-		// runtime._defer fields, followed by the function pointer to be
-		// called).
-		values = append([]llvm.Value{callback, next, fnPtr}, args...)
 
 	} else if callee, ok := instr.Call.Value.(*ssa.Function); ok {
 		// Regular function call.
 		fn := c.ir.GetFunction(callee)
 
-		// Try to find the wrapper $defer function.
-		deferName := fn.LinkName() + "$defer"
-		callback := c.mod.NamedFunction(deferName)
-		if callback.IsNil() {
-			// Not found, have to add it.
-			callback = llvm.AddFunction(c.mod, deferName, deferFuncType)
-			c.deferFuncs = append(c.deferFuncs, fn)
+		if _, ok := frame.deferFuncs[fn]; !ok {
+			frame.deferFuncs[fn] = len(frame.allDeferFuncs)
+			frame.allDeferFuncs = append(frame.allDeferFuncs, fn)
 		}
+		callback := llvm.ConstInt(c.uintptrType, uint64(frame.deferFuncs[fn]), false)
 
 		// Collect all values to be put in the struct (starting with
 		// runtime._defer fields).
 		values = []llvm.Value{callback, next}
-		valueTypes = []llvm.Type{callback.Type(), next.Type()}
 		for _, param := range instr.Call.Args {
 			llvmParam, err := c.parseExpr(frame, param)
 			if err != nil {
@@ -100,19 +98,29 @@ func (c *Compiler) emitDefer(frame *Frame, instr *ssa.Defer) error {
 
 	} else if makeClosure, ok := instr.Call.Value.(*ssa.MakeClosure); ok {
 		// Immediately applied function literal with free variables.
+
+		// Extract the context from the closure. We won't need the function
+		// pointer.
+		// TODO: ignore this closure entirely and put pointers to the free
+		// variables directly in the defer struct, avoiding a memory allocation.
 		closure, err := c.parseExpr(frame, instr.Call.Value)
 		if err != nil {
 			return err
 		}
+		context := c.builder.CreateExtractValue(closure, 0, "")
 
-		// Hopefully, LLVM will merge equivalent functions.
-		deferName := frame.fn.LinkName() + "$fpdefer"
-		callback := llvm.AddFunction(c.mod, deferName, deferFuncType)
+		// Get the callback number.
+		fn := c.ir.GetFunction(makeClosure.Fn.(*ssa.Function))
+		if _, ok := frame.deferClosureFuncs[fn]; !ok {
+			frame.deferClosureFuncs[fn] = len(frame.allDeferFuncs)
+			frame.allDeferFuncs = append(frame.allDeferFuncs, makeClosure)
+		}
+		callback := llvm.ConstInt(c.uintptrType, uint64(frame.deferClosureFuncs[fn]), false)
 
 		// Collect all values to be put in the struct (starting with
-		// runtime._defer fields, followed by the closure).
-		values = []llvm.Value{callback, next, closure}
-		valueTypes = []llvm.Type{callback.Type(), next.Type(), closure.Type()}
+		// runtime._defer fields, followed by all parameters including the
+		// context pointer).
+		values = []llvm.Value{callback, next}
 		for _, param := range instr.Call.Args {
 			llvmParam, err := c.parseExpr(frame, param)
 			if err != nil {
@@ -121,13 +129,8 @@ func (c *Compiler) emitDefer(frame *Frame, instr *ssa.Defer) error {
 			values = append(values, llvmParam)
 			valueTypes = append(valueTypes, llvmParam.Type())
 		}
-
-		thunk := ContextDeferFunction{
-			callback,
-			valueTypes,
-			makeClosure.Fn.(*ssa.Function).Signature,
-		}
-		c.ctxDeferFuncs = append(c.ctxDeferFuncs, thunk)
+		values = append(values, context)
+		valueTypes = append(valueTypes, context.Type())
 
 	} else {
 		return c.makeError(instr.Pos(), "todo: defer on uncommon function call type")
@@ -155,147 +158,172 @@ func (c *Compiler) emitDefer(frame *Frame, instr *ssa.Defer) error {
 
 // emitRunDefers emits code to run all deferred functions.
 func (c *Compiler) emitRunDefers(frame *Frame) error {
+	// Add a loop like the following:
+	//     for stack != nil {
+	//         _stack := stack
+	//         stack = stack.next
+	//         switch _stack.callback {
+	//         case 0:
+	//             // run first deferred call
+	//         case 1:
+	//             // run second deferred call
+	//             // etc.
+	//         default:
+	//             unreachable
+	//         }
+	//     }
+
+	// Create loop.
+	loophead := llvm.AddBasicBlock(frame.fn.LLVMFn, "rundefers.loophead")
+	loop := llvm.AddBasicBlock(frame.fn.LLVMFn, "rundefers.loop")
+	unreachable := llvm.AddBasicBlock(frame.fn.LLVMFn, "rundefers.default")
+	end := llvm.AddBasicBlock(frame.fn.LLVMFn, "rundefers.end")
+	c.builder.CreateBr(loophead)
+
+	// Create loop head:
+	//     for stack != nil {
+	c.builder.SetInsertPointAtEnd(loophead)
 	deferData := c.builder.CreateLoad(frame.deferPtr, "")
-	c.createRuntimeCall("rundefers", []llvm.Value{deferData}, "")
-	return nil
-}
+	stackIsNil := c.builder.CreateICmp(llvm.IntEQ, deferData, llvm.ConstPointerNull(deferData.Type()), "stackIsNil")
+	c.builder.CreateCondBr(stackIsNil, end, loop)
 
-// finalizeDefers creates thunks for deferred functions.
-func (c *Compiler) finalizeDefers() error {
-	// Create deferred function wrappers.
-	for _, fn := range c.deferFuncs {
-		// This function gets a single parameter which is a pointer to a struct
-		// (the defer frame).
-		// This struct starts with the values of runtime._defer, but after that
-		// follow the real function parameters.
-		// The job of this wrapper is to extract these parameters and to call
-		// the real function with them.
-		llvmFn := c.mod.NamedFunction(fn.LinkName() + "$defer")
-		llvmFn.SetLinkage(llvm.InternalLinkage)
-		llvmFn.SetUnnamedAddr(true)
-		entry := c.ctx.AddBasicBlock(llvmFn, "entry")
-		c.builder.SetInsertPointAtEnd(entry)
-		deferRawPtr := llvmFn.Param(0)
+	// Create loop body:
+	//     _stack := stack
+	//     stack = stack.next
+	//     switch stack.callback {
+	c.builder.SetInsertPointAtEnd(loop)
+	nextStackGEP := c.builder.CreateGEP(deferData, []llvm.Value{
+		llvm.ConstInt(c.ctx.Int32Type(), 0, false),
+		llvm.ConstInt(c.ctx.Int32Type(), 1, false), // .next field
+	}, "stack.next.gep")
+	nextStack := c.builder.CreateLoad(nextStackGEP, "stack.next")
+	c.builder.CreateStore(nextStack, frame.deferPtr)
+	gep := c.builder.CreateGEP(deferData, []llvm.Value{
+		llvm.ConstInt(c.ctx.Int32Type(), 0, false),
+		llvm.ConstInt(c.ctx.Int32Type(), 0, false), // .callback field
+	}, "callback.gep")
+	callback := c.builder.CreateLoad(gep, "callback")
+	sw := c.builder.CreateSwitch(callback, unreachable, len(frame.allDeferFuncs))
 
-		// Get the real param type and cast to it.
-		valueTypes := []llvm.Type{llvmFn.Type(), llvm.PointerType(c.mod.GetTypeByName("runtime._defer"), 0)}
-		for _, param := range fn.Params {
-			llvmType, err := c.getLLVMType(param.Type())
+	for i, callback := range frame.allDeferFuncs {
+		// Create switch case, for example:
+		//     case 0:
+		//         // run first deferred call
+		block := llvm.AddBasicBlock(frame.fn.LLVMFn, "rundefers.callback")
+		sw.AddCase(llvm.ConstInt(c.uintptrType, uint64(i), false), block)
+		c.builder.SetInsertPointAtEnd(block)
+		switch callback := callback.(type) {
+		case *ssa.CallCommon:
+			// Call on an interface value.
+			if !callback.IsInvoke() {
+				panic("expected an invoke call, not a direct call")
+			}
+
+			// Get the real defer struct type and cast to it.
+			valueTypes := []llvm.Type{c.uintptrType, llvm.PointerType(c.mod.GetTypeByName("runtime._defer"), 0), c.i8ptrType}
+			for _, arg := range callback.Args {
+				llvmType, err := c.getLLVMType(arg.Type())
+				if err != nil {
+					return err
+				}
+				valueTypes = append(valueTypes, llvmType)
+			}
+			deferFrameType := c.ctx.StructType(valueTypes, false)
+			deferFramePtr := c.builder.CreateBitCast(deferData, llvm.PointerType(deferFrameType, 0), "deferFrame")
+
+			// Extract the params from the struct (including receiver).
+			forwardParams := []llvm.Value{}
+			zero := llvm.ConstInt(c.ctx.Int32Type(), 0, false)
+			for i := 2; i < len(valueTypes); i++ {
+				gep := c.builder.CreateGEP(deferFramePtr, []llvm.Value{zero, llvm.ConstInt(c.ctx.Int32Type(), uint64(i), false)}, "gep")
+				forwardParam := c.builder.CreateLoad(gep, "param")
+				forwardParams = append(forwardParams, forwardParam)
+			}
+
+			if c.ir.SignatureNeedsContext(callback.Method.Type().(*types.Signature)) {
+				// This function takes an extra context parameter. An interface call
+				// cannot also be a closure but we have to supply the parameter
+				// anyway for platforms with a strict calling convention.
+				forwardParams = append(forwardParams, llvm.Undef(c.i8ptrType))
+			}
+
+			fnPtr, _, err := c.getInvokeCall(frame, callback)
 			if err != nil {
 				return err
 			}
-			valueTypes = append(valueTypes, llvmType)
-		}
-		deferFrameType := c.ctx.StructType(valueTypes, false)
-		deferFramePtr := c.builder.CreateBitCast(deferRawPtr, llvm.PointerType(deferFrameType, 0), "deferFrame")
+			c.createCall(fnPtr, forwardParams, "")
 
-		// Extract the params from the struct.
-		forwardParams := []llvm.Value{}
-		zero := llvm.ConstInt(c.ctx.Int32Type(), 0, false)
-		for i := range fn.Params {
-			gep := c.builder.CreateGEP(deferFramePtr, []llvm.Value{zero, llvm.ConstInt(c.ctx.Int32Type(), uint64(i+2), false)}, "gep")
-			forwardParam := c.builder.CreateLoad(gep, "param")
-			forwardParams = append(forwardParams, forwardParam)
+		case *ir.Function:
+			// Direct call.
+
+			// Get the real defer struct type and cast to it.
+			valueTypes := []llvm.Type{c.uintptrType, llvm.PointerType(c.mod.GetTypeByName("runtime._defer"), 0)}
+			for _, param := range callback.Params {
+				llvmType, err := c.getLLVMType(param.Type())
+				if err != nil {
+					return err
+				}
+				valueTypes = append(valueTypes, llvmType)
+			}
+			deferFrameType := c.ctx.StructType(valueTypes, false)
+			deferFramePtr := c.builder.CreateBitCast(deferData, llvm.PointerType(deferFrameType, 0), "deferFrame")
+
+			// Extract the params from the struct.
+			forwardParams := []llvm.Value{}
+			zero := llvm.ConstInt(c.ctx.Int32Type(), 0, false)
+			for i := range callback.Params {
+				gep := c.builder.CreateGEP(deferFramePtr, []llvm.Value{zero, llvm.ConstInt(c.ctx.Int32Type(), uint64(i+2), false)}, "gep")
+				forwardParam := c.builder.CreateLoad(gep, "param")
+				forwardParams = append(forwardParams, forwardParam)
+			}
+
+			// Call real function.
+			c.createCall(callback.LLVMFn, forwardParams, "")
+
+		case *ssa.MakeClosure:
+			// Get the real defer struct type and cast to it.
+			fn := c.ir.GetFunction(callback.Fn.(*ssa.Function))
+			valueTypes := []llvm.Type{c.uintptrType, llvm.PointerType(c.mod.GetTypeByName("runtime._defer"), 0)}
+			params := fn.Signature.Params()
+			for i := 0; i < params.Len(); i++ {
+				llvmType, err := c.getLLVMType(params.At(i).Type())
+				if err != nil {
+					return err
+				}
+				valueTypes = append(valueTypes, llvmType)
+			}
+			valueTypes = append(valueTypes, c.i8ptrType) // closure
+			deferFrameType := c.ctx.StructType(valueTypes, false)
+			deferFramePtr := c.builder.CreateBitCast(deferData, llvm.PointerType(deferFrameType, 0), "deferFrame")
+
+			// Extract the params from the struct.
+			forwardParams := []llvm.Value{}
+			zero := llvm.ConstInt(c.ctx.Int32Type(), 0, false)
+			for i := 2; i < len(valueTypes); i++ {
+				gep := c.builder.CreateGEP(deferFramePtr, []llvm.Value{zero, llvm.ConstInt(c.ctx.Int32Type(), uint64(i), false)}, "")
+				forwardParam := c.builder.CreateLoad(gep, "param")
+				forwardParams = append(forwardParams, forwardParam)
+			}
+
+			// Call deferred function.
+			c.createCall(fn.LLVMFn, forwardParams, "")
+
+		default:
+			panic("unknown deferred function type")
 		}
 
-		// Call real function (of which this is a wrapper).
-		c.createCall(fn.LLVMFn, forwardParams, "")
-		c.builder.CreateRetVoid()
+		// Branch back to the start of the loop.
+		c.builder.CreateBr(loophead)
 	}
 
-	// Create wrapper for deferred interface call.
-	for _, thunk := range c.deferInvokeFuncs {
-		// This function gets a single parameter which is a pointer to a struct
-		// (the defer frame).
-		// This struct starts with the values of runtime._defer, but after that
-		// follow the real function parameters.
-		// The job of this wrapper is to extract these parameters and to call
-		// the real function with them.
-		llvmFn := c.mod.NamedFunction(thunk.method.FullName() + "$defer")
-		llvmFn.SetLinkage(llvm.InternalLinkage)
-		llvmFn.SetUnnamedAddr(true)
-		entry := c.ctx.AddBasicBlock(llvmFn, "entry")
-		c.builder.SetInsertPointAtEnd(entry)
-		deferRawPtr := llvmFn.Param(0)
+	// Create default unreachable block:
+	//     default:
+	//         unreachable
+	//     }
+	c.builder.SetInsertPointAtEnd(unreachable)
+	c.builder.CreateUnreachable()
 
-		// Get the real param type and cast to it.
-		deferFrameType := c.ctx.StructType(thunk.valueTypes, false)
-		deferFramePtr := c.builder.CreateBitCast(deferRawPtr, llvm.PointerType(deferFrameType, 0), "deferFrame")
-
-		// Extract the params from the struct.
-		forwardParams := []llvm.Value{}
-		zero := llvm.ConstInt(c.ctx.Int32Type(), 0, false)
-		for i := range thunk.valueTypes[3:] {
-			gep := c.builder.CreateGEP(deferFramePtr, []llvm.Value{zero, llvm.ConstInt(c.ctx.Int32Type(), uint64(i+3), false)}, "gep")
-			forwardParam := c.builder.CreateLoad(gep, "param")
-			forwardParams = append(forwardParams, forwardParam)
-		}
-
-		// Call real function (of which this is a wrapper).
-		fnGEP := c.builder.CreateGEP(deferFramePtr, []llvm.Value{zero, llvm.ConstInt(c.ctx.Int32Type(), 2, false)}, "fn.gep")
-		fn := c.builder.CreateLoad(fnGEP, "fn")
-		c.createCall(fn, forwardParams, "")
-		c.builder.CreateRetVoid()
-	}
-
-	// Create wrapper for deferred function pointer call.
-	for _, thunk := range c.ctxDeferFuncs {
-		// This function gets a single parameter which is a pointer to a struct
-		// (the defer frame).
-		// This struct starts with the values of runtime._defer, but after that
-		// follows the closure and then the real parameters.
-		// The job of this wrapper is to extract this closure and these
-		// parameters and to call the function pointer with them.
-		llvmFn := thunk.fn
-		llvmFn.SetLinkage(llvm.InternalLinkage)
-		llvmFn.SetUnnamedAddr(true)
-		entry := c.ctx.AddBasicBlock(llvmFn, "entry")
-		// TODO: set the debug location - perhaps the location of the rundefers
-		// call?
-		c.builder.SetInsertPointAtEnd(entry)
-		deferRawPtr := llvmFn.Param(0)
-
-		// Get the real param type and cast to it.
-		deferFrameType := c.ctx.StructType(thunk.deferStruct, false)
-		deferFramePtr := c.builder.CreateBitCast(deferRawPtr, llvm.PointerType(deferFrameType, 0), "defer.frame")
-
-		// Extract the params from the struct.
-		forwardParams := []llvm.Value{}
-		zero := llvm.ConstInt(c.ctx.Int32Type(), 0, false)
-		for i := 3; i < len(thunk.deferStruct); i++ {
-			gep := c.builder.CreateGEP(deferFramePtr, []llvm.Value{zero, llvm.ConstInt(c.ctx.Int32Type(), uint64(i), false)}, "")
-			forwardParam := c.builder.CreateLoad(gep, "param")
-			forwardParams = append(forwardParams, forwardParam)
-		}
-
-		// Extract the closure from the struct.
-		fpGEP := c.builder.CreateGEP(deferFramePtr, []llvm.Value{
-			zero,
-			llvm.ConstInt(c.ctx.Int32Type(), 2, false),
-			llvm.ConstInt(c.ctx.Int32Type(), 1, false),
-		}, "closure.fp.ptr")
-		fp := c.builder.CreateLoad(fpGEP, "closure.fp")
-		contextGEP := c.builder.CreateGEP(deferFramePtr, []llvm.Value{
-			zero,
-			llvm.ConstInt(c.ctx.Int32Type(), 2, false),
-			llvm.ConstInt(c.ctx.Int32Type(), 0, false),
-		}, "closure.context.ptr")
-		context := c.builder.CreateLoad(contextGEP, "closure.context")
-		forwardParams = append(forwardParams, context)
-
-		// Cast the function pointer in the closure to the correct function
-		// pointer type.
-		closureType, err := c.getLLVMType(thunk.signature)
-		if err != nil {
-			return err
-		}
-		fpType := closureType.StructElementTypes()[1]
-		fpCast := c.builder.CreateBitCast(fp, fpType, "closure.fp.cast")
-
-		// Call real function (of which this is a wrapper).
-		c.createCall(fpCast, forwardParams, "")
-		c.builder.CreateRetVoid()
-	}
-
+	// End of loop.
+	c.builder.SetInsertPointAtEnd(end)
 	return nil
 }

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -77,14 +77,11 @@ interface
     interface.go for a detailed description of how typeasserts and interface
     calls are implemented.
 
-function pointer
-    A function pointer has two representations: a literal function pointer and a
-    fat function pointer in the form of ``{context, function pointer}``. Which
-    representation is chosen depends on the AnalyseFunctionPointers pass in
-    `ir/passes.go <https://github.com/aykevl/tinygo/blob/master/ir/passes.go>`_:
-    it tries to use a raw function pointer but will use a fat function pointer
-    if there is a closure or bound method somewhere in the program with the
-    exact same signature.
+function value
+    A function value is a fat function pointer in the form of  ``{context,
+    function pointer}`` where context is a pointer which may have any value.
+    The function pointer is expected to be called with the context as the last
+    parameter in all cases.
 
 goroutine
     A goroutine is a linked list of `LLVM coroutines

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -56,13 +56,14 @@ func Run(mod llvm.Module, targetData llvm.TargetData, debug bool) error {
 	}
 
 	// Do this in a separate step to avoid corrupting the iterator above.
+	undefPtr := llvm.Undef(llvm.PointerType(mod.Context().Int8Type(), 0))
 	for _, call := range initCalls {
 		initName := call.CalledValue().Name()
 		if !strings.HasSuffix(initName, ".init") {
 			return errors.New("expected all instructions in " + name + " to be *.init() calls")
 		}
 		pkgName := initName[:len(initName)-5]
-		_, err := e.Function(call.CalledValue(), nil, pkgName)
+		_, err := e.Function(call.CalledValue(), []Value{&LocalValue{e, undefPtr}}, pkgName)
 		if err == ErrUnreachable {
 			break
 		}

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -19,33 +19,30 @@ import (
 // View on all functions, types, and globals in a program, with analysis
 // results.
 type Program struct {
-	Program           *ssa.Program
-	mainPkg           *ssa.Package
-	Functions         []*Function
-	functionMap       map[*ssa.Function]*Function
-	Globals           []*Global
-	globalMap         map[*ssa.Global]*Global
-	comments          map[string]*ast.CommentGroup
-	NamedTypes        []*NamedType
-	needsScheduler    bool
-	goCalls           []*ssa.Go
-	typesInInterfaces map[string]struct{} // see AnalyseInterfaceConversions
-	fpWithContext     map[string]struct{} // see AnalyseFunctionPointers
+	Program        *ssa.Program
+	mainPkg        *ssa.Package
+	Functions      []*Function
+	functionMap    map[*ssa.Function]*Function
+	Globals        []*Global
+	globalMap      map[*ssa.Global]*Global
+	comments       map[string]*ast.CommentGroup
+	NamedTypes     []*NamedType
+	needsScheduler bool
+	goCalls        []*ssa.Go
 }
 
 // Function or method.
 type Function struct {
 	*ssa.Function
-	LLVMFn       llvm.Value
-	linkName     string      // go:linkname, go:export, go:interrupt
-	exported     bool        // go:export
-	nobounds     bool        // go:nobounds
-	blocking     bool        // calculated by AnalyseBlockingRecursive
-	flag         bool        // used by dead code elimination
-	interrupt    bool        // go:interrupt
-	addressTaken bool        // used as function pointer, calculated by AnalyseFunctionPointers
-	parents      []*Function // calculated by AnalyseCallgraph
-	children     []*Function // calculated by AnalyseCallgraph
+	LLVMFn    llvm.Value
+	linkName  string      // go:linkname, go:export, go:interrupt
+	exported  bool        // go:export
+	nobounds  bool        // go:nobounds
+	blocking  bool        // calculated by AnalyseBlockingRecursive
+	flag      bool        // used by dead code elimination
+	interrupt bool        // go:interrupt
+	parents   []*Function // calculated by AnalyseCallgraph
+	children  []*Function // calculated by AnalyseCallgraph
 }
 
 // Global variable, possibly constant.

--- a/src/runtime/defer.go
+++ b/src/runtime/defer.go
@@ -1,29 +1,9 @@
 package runtime
 
-// Defer statements are implemented by transforming the function in the
-// following way:
-//   * Creating an alloca in the entry block that contains a pointer (initially
-//     null) to the linked list of defer frames.
-//   * Every time a defer statement is executed, a new defer frame is created
-//     using alloca with a pointer to the previous defer frame, and the head
-//     pointer in the entry block is replaced with a pointer to this defer
-//     frame.
-//   * On return, runtime.rundefers is called which calls all deferred functions
-//     from the head of the linked list until it has gone through all defer
-//     frames.
-
-import "unsafe"
-
-type deferContext unsafe.Pointer
+// Some helper types for the defer statement.
+// See compiler/defer.go for details.
 
 type _defer struct {
-	callback func(*_defer)
+	callback uintptr // callback number
 	next     *_defer
-}
-
-func rundefers(stack *_defer) {
-	for stack != nil {
-		stack.callback(stack)
-		stack = stack.next
-	}
 }

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -2,7 +2,7 @@ package runtime
 
 // trap is a compiler hint that this function cannot be executed. It is
 // translated into either a trap instruction or a call to abort().
-//go:linkname trap llvm.trap
+//go:export llvm.trap
 func trap()
 
 // Builtin function panic(msg), used as a compiler intrinsic.

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -6,16 +6,25 @@ import (
 	"unsafe"
 )
 
-func _Cfunc_putchar(c int) int
-func _Cfunc_usleep(usec uint) int
-func _Cfunc_malloc(size uintptr) unsafe.Pointer
-func _Cfunc_abort()
-func _Cfunc_clock_gettime(clk_id uint, ts *timespec)
+//go:export putchar
+func _putchar(c int) int
+
+//go:export usleep
+func usleep(usec uint) int
+
+//go:export malloc
+func malloc(size uintptr) unsafe.Pointer
+
+//go:export abort
+func abort()
+
+//go:export clock_gettime
+func clock_gettime(clk_id uint, ts *timespec)
 
 const heapSize = 1 * 1024 * 1024 // 1MB to start
 
 var (
-	heapStart = uintptr(_Cfunc_malloc(heapSize))
+	heapStart = uintptr(malloc(heapSize))
 	heapEnd   = heapStart + heapSize
 )
 
@@ -45,11 +54,11 @@ func main() int {
 }
 
 func putchar(c byte) {
-	_Cfunc_putchar(int(c))
+	_putchar(int(c))
 }
 
 func sleepTicks(d timeUnit) {
-	_Cfunc_usleep(uint(d) / 1000)
+	usleep(uint(d) / 1000)
 }
 
 // Return monotonic time in nanoseconds.
@@ -57,15 +66,10 @@ func sleepTicks(d timeUnit) {
 // TODO: noescape
 func monotime() uint64 {
 	ts := timespec{}
-	_Cfunc_clock_gettime(CLOCK_MONOTONIC_RAW, &ts)
+	clock_gettime(CLOCK_MONOTONIC_RAW, &ts)
 	return uint64(ts.tv_sec)*1000*1000*1000 + uint64(ts.tv_nsec)
 }
 
 func ticks() timeUnit {
 	return timeUnit(monotime())
-}
-
-func abort() {
-	// panic() exits with exit code 2.
-	_Cfunc_abort()
 }

--- a/src/runtime/runtime_wasm.go
+++ b/src/runtime/runtime_wasm.go
@@ -8,16 +8,16 @@ const tickMicros = 1
 
 var timestamp timeUnit
 
-// CommonWA: io_get_stdout
-func _Cfunc_io_get_stdout() int32
+//go:export io_get_stdout
+func io_get_stdout() int32
 
-// CommonWA: resource_write
-func _Cfunc_resource_write(id int32, ptr *uint8, len int32) int32
+//go:export resource_write
+func resource_write(id int32, ptr *uint8, len int32) int32
 
 var stdout int32
 
 func init() {
-	stdout = _Cfunc_io_get_stdout()
+	stdout = io_get_stdout()
 }
 
 //go:export _start
@@ -32,7 +32,7 @@ func cwa_main() {
 }
 
 func putchar(c byte) {
-	_Cfunc_resource_write(stdout, &c, 1)
+	resource_write(stdout, &c, 1)
 }
 
 func sleepTicks(d timeUnit) {

--- a/src/runtime/scheduler.go
+++ b/src/runtime/scheduler.go
@@ -31,16 +31,16 @@ const schedulerDebug = false
 // must not be used directly, it is meant to be used as an opaque *i8 in LLVM.
 type coroutine uint8
 
-//go:linkname resume llvm.coro.resume
+//go:export llvm.coro.resume
 func (t *coroutine) resume()
 
-//go:linkname destroy llvm.coro.destroy
+//go:export llvm.coro.destroy
 func (t *coroutine) destroy()
 
-//go:linkname done llvm.coro.done
+//go:export llvm.coro.done
 func (t *coroutine) done() bool
 
-//go:linkname _promise llvm.coro.promise
+//go:export llvm.coro.promise
 func (t *coroutine) _promise(alignment int32, from bool) unsafe.Pointer
 
 // Get the promise belonging to a task.


### PR DESCRIPTION
Depends on #100.

This simplifies the compiler a lot and avoids lots of tricky edge cases that are rarely tested. Resulting binary size is unchanged on Linux/x86 and Cortex-M0 and is slightly increased in WebAssembly. The increase in binary size in WebAssembly is probably because of the strict requirements on the number of parameters in function calls.

@deadprogram 