### PR TITLE
Makefile needs to look at changes in loader directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ gen-device-stm32:
 
 
 # Build the Go compiler.
-build/tgo: *.go compiler/*.go ir/*.go loader/*.go
+build/tgo: *.go compiler/*.go interp/*.go loader/*.go ir/*.go
 	@mkdir -p build
 	go build -o build/tgo -i .
 

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ gen-device-stm32:
 
 
 # Build the Go compiler.
-build/tgo: *.go compiler/*.go ir/*.go
+build/tgo: *.go compiler/*.go ir/*.go loader/*.go
 	@mkdir -p build
 	go build -o build/tgo -i .
 


### PR DESCRIPTION
The Makefile now needs to look at changes to files in the `loader` directory to decide if a rebuild is required for the `tgo` task.
