### PR TITLE
Add cflags and ldflags to compiler CLI for CGo compilation/linking

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -32,7 +32,8 @@ func init() {
 type Config struct {
 	Triple     string   // LLVM target triple, e.g. x86_64-unknown-linux-gnu (empty string means default)
 	GC         string   // garbage collection strategy
-	CFlags     []string // flags to pass to cgo
+	CFlags     []string // cflags to pass to cgo
+	LDFlags    []string // ldflags to pass to cgo
 	DumpSSA    bool     // dump Go SSA, for compiler debugging
 	Debug      bool     // add debug symbols for gdb
 	RootDir    string   // GOROOT for TinyGo

--- a/loader/libclang.go
+++ b/loader/libclang.go
@@ -5,7 +5,6 @@ package loader
 
 import (
 	"errors"
-	"fmt"
 	"unsafe"
 )
 
@@ -46,9 +45,6 @@ func (info *fileInfo) parseFragment(fragment string, cflags []string) error {
 		cmdargs[i] = s
 		defer C.free(unsafe.Pointer(s))
 	}
-
-	// TODO: remove this once cflags working as expected
-	fmt.Println(cflags)
 
 	var unit C.CXTranslationUnit
 	errCode := C.clang_parseTranslationUnit2(

--- a/loader/libclang.go
+++ b/loader/libclang.go
@@ -5,6 +5,7 @@ package loader
 
 import (
 	"errors"
+	"fmt"
 	"unsafe"
 )
 
@@ -45,6 +46,9 @@ func (info *fileInfo) parseFragment(fragment string, cflags []string) error {
 		cmdargs[i] = s
 		defer C.free(unsafe.Pointer(s))
 	}
+
+	// TODO: remove this once cflags working as expected
+	fmt.Println(cflags)
 
 	var unit C.CXTranslationUnit
 	errCode := C.clang_parseTranslationUnit2(

--- a/main.go
+++ b/main.go
@@ -34,6 +34,8 @@ type BuildConfig struct {
 	debug      bool
 	printSizes string
 	initInterp bool
+	cFlags     []string
+	ldFlags    []string
 }
 
 // Helper function for Compiler object.
@@ -44,7 +46,8 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 	compilerConfig := compiler.Config{
 		Triple:     spec.Triple,
 		GC:         config.gc,
-		CFlags:     spec.CFlags,
+		CFlags:     append(spec.CFlags, config.cFlags...),
+		LDFlags:    append(spec.LDFlags, config.ldFlags...),
 		Debug:      config.debug,
 		DumpSSA:    config.dumpSSA,
 		RootDir:    sourceDir(),
@@ -497,6 +500,8 @@ func main() {
 	ocdOutput := flag.Bool("ocd-output", false, "print OCD daemon output during debug")
 	initInterp := flag.Bool("initinterp", true, "enable/disable partial evaluator of generated IR")
 	port := flag.String("port", "/dev/ttyACM0", "flash port")
+	cFlags := flag.String("cflags", "", "additional cflags for compiler")
+	ldFlags := flag.String("ldflags", "", "additional ldflags for linker")
 
 	if len(os.Args) < 2 {
 		fmt.Fprintln(os.Stderr, "No command-line arguments supplied.")
@@ -514,6 +519,8 @@ func main() {
 		debug:      !*nodebug,
 		printSizes: *printSize,
 		initInterp: *initInterp,
+		cFlags:     strings.Split(*cFlags, " "),
+		ldFlags:    strings.Split(*ldFlags, " "),
 	}
 
 	os.Setenv("CC", "clang -target="+*target)

--- a/main.go
+++ b/main.go
@@ -45,13 +45,8 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 	}
 
 	// Append command line passed CFlags and LDFlags
-	if len(config.cFlags) > 0 && config.cFlags[0] != "" {
-		spec.CFlags = append(spec.CFlags, config.cFlags...)
-	}
-
-	if len(config.ldFlags) > 0 && config.ldFlags[0] != "" {
-		spec.LDFlags = append(spec.LDFlags, config.ldFlags...)
-	}
+	spec.CFlags = append(spec.CFlags, config.cFlags...)
+	spec.LDFlags = append(spec.LDFlags, config.ldFlags...)
 
 	compilerConfig := compiler.Config{
 		Triple:     spec.Triple,
@@ -529,8 +524,14 @@ func main() {
 		debug:      !*nodebug,
 		printSizes: *printSize,
 		initInterp: *initInterp,
-		cFlags:     strings.Split(*cFlags, " "),
-		ldFlags:    strings.Split(*ldFlags, " "),
+	}
+
+	if *cFlags != "" {
+		config.cFlags = strings.Split(*cFlags, " ")
+	}
+
+	if *ldFlags != "" {
+		config.ldFlags = strings.Split(*ldFlags, " ")
 	}
 
 	os.Setenv("CC", "clang -target="+*target)

--- a/main.go
+++ b/main.go
@@ -43,11 +43,21 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 	if config.gc == "" && spec.GC != "" {
 		config.gc = spec.GC
 	}
+
+	// Append command line passed CFlags and LDFlags
+	if len(config.cFlags) > 0 && config.cFlags[0] != "" {
+		spec.CFlags = append(spec.CFlags, config.cFlags...)
+	}
+
+	if len(config.ldFlags) > 0 && config.ldFlags[0] != "" {
+		spec.LDFlags = append(spec.LDFlags, config.ldFlags...)
+	}
+
 	compilerConfig := compiler.Config{
 		Triple:     spec.Triple,
 		GC:         config.gc,
-		CFlags:     append(spec.CFlags, config.cFlags...),
-		LDFlags:    append(spec.LDFlags, config.ldFlags...),
+		CFlags:     spec.CFlags,
+		LDFlags:    spec.LDFlags,
 		Debug:      config.debug,
 		DumpSSA:    config.dumpSSA,
 		RootDir:    sourceDir(),


### PR DESCRIPTION
This PR adds two new compiler flags `-cflags` and `-ldflags` to the CLI for CGo compilation that needs to be set at compile/link time.

For example, to add 2 include directories using the `-I` flags that are needed for CGo compilation:

```
tinygo compile -target=pca10040 -size=short -cflags="-I/path/to/include -I/path/to/other/include" projectfolder
```
