### PR TITLE
A flag to enable i64 parameters in WebAssembly

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -30,16 +30,17 @@ func init() {
 
 // Configure the compiler.
 type Config struct {
-	Triple     string   // LLVM target triple, e.g. x86_64-unknown-linux-gnu (empty string means default)
-	GC         string   // garbage collection strategy
-	CFlags     []string // cflags to pass to cgo
-	LDFlags    []string // ldflags to pass to cgo
-	DumpSSA    bool     // dump Go SSA, for compiler debugging
-	Debug      bool     // add debug symbols for gdb
-	RootDir    string   // GOROOT for TinyGo
-	GOPATH     string   // GOPATH, like `go env GOPATH`
-	BuildTags  []string // build tags for TinyGo (empty means {runtime.GOOS/runtime.GOARCH})
-	InitInterp bool     // use new init interpretation, meaning the old one is disabled
+	Triple        string   // LLVM target triple, e.g. x86_64-unknown-linux-gnu (empty string means default)
+	GC            string   // garbage collection strategy
+	CFlags        []string // cflags to pass to cgo
+	LDFlags       []string // ldflags to pass to cgo
+	DumpSSA       bool     // dump Go SSA, for compiler debugging
+	Debug         bool     // add debug symbols for gdb
+	RootDir       string   // GOROOT for TinyGo
+	GOPATH        string   // GOPATH, like `go env GOPATH`
+	BuildTags     []string // build tags for TinyGo (empty means {runtime.GOOS/runtime.GOARCH})
+	InitInterp    bool     // use new init interpretation, meaning the old one is disabled
+	WasmI64Enable bool     // enable returning i64 in exported WebAssembly functions
 }
 
 type Compiler struct {
@@ -3117,6 +3118,7 @@ func (c *Compiler) NonConstGlobals() {
 // Replace i64 in an external function with a stack-allocated i64*, to work
 // around the lack of 64-bit integers in JavaScript (commonly used together with
 // WebAssembly). Once that's resolved, this pass may be avoided.
+// See also the --wasmi64enable flag
 // https://github.com/WebAssembly/design/issues/1172
 func (c *Compiler) ExternalInt64AsPtr() error {
 	int64Type := c.ctx.Int64Type()
@@ -3219,8 +3221,8 @@ func (c *Compiler) ExternalInt64AsPtr() error {
 			entryBlock := llvm.AddBasicBlock(externalFn, "entry")
 			c.builder.SetInsertPointAtEnd(entryBlock)
 			var callParams []llvm.Value
-			if fnType.ReturnType() == int64Type {
-				return errors.New("todo: i64 return value in exported function")
+			if fnType.ReturnType() == int64Type && !c.Config.WasmI64Enable {
+				return errors.New("i64 return value in exported functions disallowed by default, use --wasmi64enable for non-JS wasm targets")
 			}
 			for i, origParam := range fn.Params() {
 				paramValue := externalFn.Param(i)

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -3222,7 +3222,8 @@ func (c *Compiler) ExternalInt64AsPtr() error {
 			c.builder.SetInsertPointAtEnd(entryBlock)
 			var callParams []llvm.Value
 			if fnType.ReturnType() == int64Type {
-				return errors.New("i64 return value in exported functions disallowed by default, use -wasm-abi=generic to override")
+				return errors.New("not yet implemented: exported function returns i64 with -wasm-abi=js; " +
+					"see https://tinygo.org/compiler-internals/calling-convention/")
 			}
 			for i, origParam := range fn.Params() {
 				paramValue := externalFn.Param(i)

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -130,8 +130,8 @@ somewhat compatible with the C calling convention but with a few quirks:
     pointers. This avoids some overhead in the C calling convention and makes
     the work of the LLVM optimizers easier.
 
-  * The WebAssembly target never exports or imports a ``i64`` (``int64``,
-    ``uint64``) parameter. Instead, it replaces them with ``i64*``, allocating
+  * The WebAssembly target by default doesn't export or import ``i64`` (``int64``,
+    ``uint64``) parameters. Instead, it replaces them with ``i64*``, allocating
     the value on the stack. In other words, imported functions are called with a
     64-bit integer on the stack and exported functions must be called with a
     pointer to a 64-bit integer somewhere in linear memory.
@@ -144,10 +144,15 @@ somewhat compatible with the C calling convention but with a few quirks:
     calling convention workaround may be removed. Also see `this wasm-bindgen
     issue <https://github.com/rustwasm/wasm-bindgen/issues/35>`_.
 
+    Currently there are also non-browser WebAssembly execution environments
+    that do not have this limitation. Use the `--wasmi64enable` flag to remove
+    the behavior described above and enable emitting functions with i64
+    parameters directly.
+
   * The WebAssembly target does not return variables directly that cannot be
-    handled by JavaScript (``struct``, ``i64``, multiple return values, etc).
-    Instead, they are stored into a pointer passed as the first parameter by the
-    caller.
+    handled by JavaScript (see above about ``i64``, also ``struct``, multiple
+    return values, etc). Instead, they are stored into a pointer passed as the
+    first parameter by the caller.
 
     This is the calling convention as implemented by LLVM, with the extension
     that ``i64`` return values are returned in the same way as aggregate types.

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -145,7 +145,7 @@ somewhat compatible with the C calling convention but with a few quirks:
     issue <https://github.com/rustwasm/wasm-bindgen/issues/35>`_.
 
     Currently there are also non-browser WebAssembly execution environments
-    that do not have this limitation. Use the `--wasmi64enable` flag to remove
+    that do not have this limitation. Use the `-wasm-abi=generic` flag to remove
     the behavior described above and enable emitting functions with i64
     parameters directly.
 


### PR DESCRIPTION
Rationale: I've been working on writing wasm modules for https://github.com/paritytech/substrate - long story short, it's a non-browser execution environment for wasm code with a rigid API. The calling convention there is to "return" a memory slice (32-bit pointer and length packed as `i64`). Therefore, I needed direct support of i64s.

As far as I can see, nothing prevents Tinygo from actually producing such code, apart from the built-in safety checker. So why not have a flag to disable that limitation?