### PR TITLE
Reduce code size for AVR

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -31,6 +31,7 @@ func init() {
 // Configure the compiler.
 type Config struct {
 	Triple     string   // LLVM target triple, e.g. x86_64-unknown-linux-gnu (empty string means default)
+	CPU        string   // LLVM CPU name, e.g. atmega328p (empty string means default)
 	GC         string   // garbage collection strategy
 	CFlags     []string // cflags to pass to cgo
 	LDFlags    []string // ldflags to pass to cgo
@@ -108,7 +109,7 @@ func NewCompiler(pkgName string, config Config) (*Compiler, error) {
 	if err != nil {
 		return nil, err
 	}
-	c.machine = target.CreateTargetMachine(config.Triple, "", "", llvm.CodeGenLevelDefault, llvm.RelocStatic, llvm.CodeModelDefault)
+	c.machine = target.CreateTargetMachine(config.Triple, config.CPU, "", llvm.CodeGenLevelDefault, llvm.RelocStatic, llvm.CodeModelDefault)
 	c.targetData = c.machine.CreateTargetData()
 
 	c.ctx = llvm.NewContext()

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 
 	compilerConfig := compiler.Config{
 		Triple:     spec.Triple,
+		CPU:        spec.CPU,
 		GC:         config.gc,
 		CFlags:     spec.CFlags,
 		LDFlags:    spec.LDFlags,

--- a/target.go
+++ b/target.go
@@ -20,6 +20,7 @@ import (
 type TargetSpec struct {
 	Inherits   []string `json:"inherits"`
 	Triple     string   `json:"llvm-target"`
+	CPU        string   `json:"cpu"`
 	BuildTags  []string `json:"build-tags"`
 	GC         string   `json:"gc"`
 	Compiler   string   `json:"compiler"`
@@ -43,6 +44,9 @@ func (spec *TargetSpec) copyProperties(spec2 *TargetSpec) {
 	spec.Inherits = append(spec.Inherits, spec2.Inherits...)
 	if spec2.Triple != "" {
 		spec.Triple = spec2.Triple
+	}
+	if spec2.CPU != "" {
+		spec.CPU = spec2.CPU
 	}
 	spec.BuildTags = append(spec.BuildTags, spec2.BuildTags...)
 	if spec2.GC != "" {

--- a/targets/arduino.json
+++ b/targets/arduino.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["avr"],
 	"llvm-target": "avr-atmel-none",
+	"cpu": "atmega328p",
 	"build-tags": ["arduino", "atmega328p", "atmega", "avr5"],
 	"cflags": [
 		"-mmcu=atmega328p"

--- a/targets/digispark.json
+++ b/targets/digispark.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["avr"],
 	"llvm-target": "avr-atmel-none",
+	"cpu": "attiny85",
 	"build-tags": ["digispark", "attiny85", "attiny", "avr2", "avr25"],
 	"cflags": [
 		"-mmcu=attiny85"


### PR DESCRIPTION
This PR reduces code size by ~7% on atmega328p simply by specifying the target CPU name. Apparently, without it LLVM falls back to a lowest-common-denominator CPU.

I got this idea after talking with @Rahix about bugs in the AVR backend of LLVM.

@deadprogram what do you think? I have tested both blinky on the Uno and Digispark and tested the (more complex) echo example on the Uno.