### PR TITLE
all: add support for more architectures and GOOS/GOARCH

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -32,6 +32,8 @@ func init() {
 type Config struct {
 	Triple     string   // LLVM target triple, e.g. x86_64-unknown-linux-gnu (empty string means default)
 	CPU        string   // LLVM CPU name, e.g. atmega328p (empty string means default)
+	GOOS       string   //
+	GOARCH     string   //
 	GC         string   // garbage collection strategy
 	CFlags     []string // cflags to pass to cgo
 	LDFlags    []string // ldflags to pass to cgo
@@ -39,7 +41,7 @@ type Config struct {
 	Debug      bool     // add debug symbols for gdb
 	RootDir    string   // GOROOT for TinyGo
 	GOPATH     string   // GOPATH, like `go env GOPATH`
-	BuildTags  []string // build tags for TinyGo (empty means {runtime.GOOS/runtime.GOARCH})
+	BuildTags  []string // build tags for TinyGo (empty means {Config.GOOS/Config.GOARCH})
 	InitInterp bool     // use new init interpretation, meaning the old one is disabled
 }
 
@@ -97,7 +99,7 @@ func NewCompiler(pkgName string, config Config) (*Compiler, error) {
 		config.Triple = llvm.DefaultTargetTriple()
 	}
 	if len(config.BuildTags) == 0 {
-		config.BuildTags = []string{runtime.GOOS, runtime.GOARCH}
+		config.BuildTags = []string{config.GOOS, config.GOARCH}
 	}
 	c := &Compiler{
 		Config:  config,
@@ -178,8 +180,6 @@ func (c *Compiler) selectGC() string {
 // Compile the given package path or .go file path. Return an error when this
 // fails (in any stage).
 func (c *Compiler) Compile(mainPath string) error {
-	tripleSplit := strings.Split(c.Triple, "-")
-
 	// Prefix the GOPATH with the system GOROOT, as GOROOT is already set to
 	// the TinyGo root.
 	gopath := c.GOPATH
@@ -195,8 +195,8 @@ func (c *Compiler) Compile(mainPath string) error {
 	}
 	lprogram := &loader.Program{
 		Build: &build.Context{
-			GOARCH:      tripleSplit[0],
-			GOOS:        tripleSplit[2],
+			GOARCH:      c.GOARCH,
+			GOOS:        c.GOOS,
 			GOROOT:      c.RootDir,
 			GOPATH:      gopath,
 			CgoEnabled:  true,

--- a/main.go
+++ b/main.go
@@ -52,6 +52,8 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 	compilerConfig := compiler.Config{
 		Triple:     spec.Triple,
 		CPU:        spec.CPU,
+		GOOS:       spec.GOOS,
+		GOARCH:     spec.GOARCH,
 		GC:         config.gc,
 		CFlags:     spec.CFlags,
 		LDFlags:    spec.LDFlags,

--- a/src/runtime/arch_386.go
+++ b/src/runtime/arch_386.go
@@ -1,11 +1,11 @@
 package runtime
 
-const GOARCH = "amd64"
+const GOARCH = "386"
 
 // The bitness of the CPU (e.g. 8, 32, 64).
-const TargetBits = 64
+const TargetBits = 32
 
 // Align on word boundary.
 func align(ptr uintptr) uintptr {
-	return (ptr + 7) &^ 7
+	return (ptr + 3) &^ 3
 }

--- a/src/runtime/arch_arm.go
+++ b/src/runtime/arch_arm.go
@@ -1,11 +1,11 @@
 package runtime
 
-const GOARCH = "amd64"
+const GOARCH = "arm"
 
 // The bitness of the CPU (e.g. 8, 32, 64).
-const TargetBits = 64
+const TargetBits = 32
 
 // Align on word boundary.
 func align(ptr uintptr) uintptr {
-	return (ptr + 7) &^ 7
+	return (ptr + 3) &^ 3
 }

--- a/src/runtime/arch_arm64.go
+++ b/src/runtime/arch_arm64.go
@@ -1,6 +1,6 @@
 package runtime
 
-const GOARCH = "amd64"
+const GOARCH = "arm64"
 
 // The bitness of the CPU (e.g. 8, 32, 64).
 const TargetBits = 64

--- a/targets/avr.json
+++ b/targets/avr.json
@@ -1,5 +1,7 @@
 {
 	"build-tags": ["avr", "js", "wasm"],
+	"goos": "js",
+	"goarch": "wasm",
 	"compiler": "avr-gcc",
 	"linker": "avr-gcc",
 	"objcopy": "avr-objcopy",

--- a/targets/cortex-m.json
+++ b/targets/cortex-m.json
@@ -1,5 +1,7 @@
 {
 	"build-tags": ["tinygo.arm", "js", "wasm"],
+	"goos": "js",
+	"goarch": "wasm",
 	"compiler": "clang-7",
 	"gc": "marksweep",
 	"linker": "arm-none-eabi-ld",


### PR DESCRIPTION
This commit does two things:

  * It adds support for the GOOS and GOARCH environment variables. They
    fall back to runtime.GO* only when not available.
  * It adds support for 3 new architectures: 386, arm, and arm64. For
    now, this is Linux-only.

@deadprogram?