### PR TITLE
Allow slicing arrays of a named type; better error message on invalid slicing

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -2333,8 +2333,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		switch typ := expr.X.Type().Underlying().(type) {
 		case *types.Pointer: // pointer to array
 			// slice an array
-			array := typ.Elem().Underlying().(*types.Array)
-			length := array.Len()
+			length := typ.Elem().Underlying().(*types.Array).Len()
 			llvmLen := llvm.ConstInt(c.uintptrType, uint64(length), false)
 			if high.IsNil() {
 				high = llvmLen

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -2333,14 +2333,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		switch typ := expr.X.Type().Underlying().(type) {
 		case *types.Pointer: // pointer to array
 			// slice an array
-			array, ok := typ.Elem().(*types.Array)
-			if !ok {
-				// maybe it's a named array type?
-				array, ok = typ.Elem().Underlying().(*types.Array)
-				if !ok {
-					panic("slicing a value that is not an array at " + c.ir.Program.Fset.Position(expr.Pos()).String())
-				}
-			}
+			array := typ.Elem().Underlying().(*types.Array)
 			length := array.Len()
 			llvmLen := llvm.ConstInt(c.uintptrType, uint64(length), false)
 			if high.IsNil() {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -2333,7 +2333,15 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		switch typ := expr.X.Type().Underlying().(type) {
 		case *types.Pointer: // pointer to array
 			// slice an array
-			length := typ.Elem().(*types.Array).Len()
+			array, ok := typ.Elem().(*types.Array)
+			if !ok {
+				// maybe it's a named array type?
+				array, ok = typ.Elem().Underlying().(*types.Array)
+				if !ok {
+					panic("slicing a value that is not an array at " + c.ir.Program.Fset.Position(expr.Pos()).String())
+				}
+			}
+			length := array.Len()
 			llvmLen := llvm.ConstInt(c.uintptrType, uint64(length), false)
 			if high.IsNil() {
 				high = llvmLen

--- a/testdata/slice.go
+++ b/testdata/slice.go
@@ -92,7 +92,7 @@ func main() {
 	}
 	println()
 
-	// Verify the fix for https://github.com/aykevl/tinygo/pull/119
+	// Verify the fix in https://github.com/aykevl/tinygo/pull/119
 	var unnamed [32]byte
 	var named MySlice
 	assert(len(unnamed[:]) == 32)

--- a/testdata/slice.go
+++ b/testdata/slice.go
@@ -1,5 +1,7 @@
 package main
 
+type MySlice [32]byte
+
 func main() {
 	l := 5
 	foo := []int{1, 2, 4, 5}
@@ -89,6 +91,12 @@ func main() {
 		print(" ", n)
 	}
 	println()
+
+	// Verify the fix for https://github.com/aykevl/tinygo/pull/119
+	var unnamed [32]byte
+	var named MySlice
+	assert(len(unnamed[:]) == 32)
+	assert(len(named[:]) == 32)
 }
 
 func printslice(name string, s []int) {


### PR DESCRIPTION
Currently the compiler crashes on this:

```
type MyHash [32]byte
func (m *MyHash) MyMethod {
    methodExpectingByteSlice(m[:])
}
```

This patch fixes that problem (and also provides a better error message if something dodgy is being sliced).

