### PR TITLE
tools: use env to search path for python3

### DIFF
--- a/tools/gen-device-avr.py
+++ b/tools/gen-device-avr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/tools/gen-device-svd.py
+++ b/tools/gen-device-svd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import os


### PR DESCRIPTION
In many cases python3 may not be in /usr/bin, /usr/bin/env is SUS portable alternative to using explicit path.