### PR TITLE
Implement i2c operations for stm32f103xx

### DIFF
--- a/src/machine/board_bluepill.go
+++ b/src/machine/board_bluepill.go
@@ -57,3 +57,9 @@ const (
 	SPI0_MOSI_PIN = PA7
 	SPI0_MISO_PIN = PA6
 )
+
+// I2C pins
+const (
+	SDA_PIN = PB7
+	SCL_PIN = PB6
+)

--- a/src/machine/i2c.go
+++ b/src/machine/i2c.go
@@ -1,4 +1,4 @@
-// +build avr nrf
+// +build avr nrf stm32f103xx
 
 package machine
 

--- a/src/machine/machine_stm32f103xx.go
+++ b/src/machine/machine_stm32f103xx.go
@@ -365,12 +365,18 @@ func (i2c I2C) Configure(config I2CConfig) {
 		i2c.Bus.TRISE = stm32.RegValue(pclk1Mhz)
 
 	case TWI_FREQ_400KHZ:
-		// TODO: fast mode
-		// Set Maximum Rise Time for fast mode
-		//i2c.Bus.TRISE = stm32.RegValue(((freqRange * 300) / 1000) + 1)
-
 		// Fast mode speed calculation
-		//i2c.Bus.CCR = stm32.RegValue((pclk1 / (TWI_FREQ_400KHZ * 3)) | stm32.I2C_CCR_F_S)
+		ccr := pclk1 / (config.Frequency * 3)
+		i2c.Bus.CCR = stm32.RegValue(ccr)
+
+		// duty cycle 2
+		i2c.Bus.CCR &^= stm32.I2C_CCR_DUTY
+
+		// frequency fast mode
+		i2c.Bus.CCR |= stm32.I2C_CCR_F_S
+
+		// Set Maximum Rise Time for fast mode
+		i2c.Bus.TRISE = stm32.RegValue(((pclk1Mhz * 300) / 1000))
 	}
 
 	// re-enable the selected I2C peripheral

--- a/src/runtime/runtime_stm32f103xx.go
+++ b/src/runtime/runtime_stm32f103xx.go
@@ -21,13 +21,19 @@ func putchar(c byte) {
 
 // initCLK sets clock to 72MHz using HSE 8MHz crystal w/ PLL X 9 (8MHz x 9 = 72MHz).
 func initCLK() {
-	stm32.FLASH.ACR |= stm32.FLASH_ACR_LATENCY_2 // Two wait states, per datasheet
-	stm32.RCC.CFGR |= stm32.RCC_CFGR_PPRE1_DIV_2 // prescale PCLK1 = HCLK/2
-	stm32.RCC.CFGR |= stm32.RCC_CFGR_PPRE2_DIV_4 // prescale PCLK2 = HCLK/4
-	stm32.RCC.CR |= stm32.RCC_CR_HSEON           // enable HSE clock
+	stm32.FLASH.ACR |= stm32.FLASH_ACR_LATENCY_2    // Two wait states, per datasheet
+	stm32.RCC.CFGR |= stm32.RCC_CFGR_PPRE1_DIV_2    // prescale PCLK1 = HCLK/2
+	stm32.RCC.CFGR |= stm32.RCC_CFGR_PPRE2_DIV_NONE // prescale PCLK2 = HCLK/1
+	stm32.RCC.CR |= stm32.RCC_CR_HSEON              // enable HSE clock
 
 	// wait for the HSEREADY flag
 	for (stm32.RCC.CR & stm32.RCC_CR_HSERDY) == 0 {
+	}
+
+	stm32.RCC.CR |= stm32.RCC_CR_HSION // enable HSI clock
+
+	// wait for the HSIREADY flag
+	for (stm32.RCC.CR & stm32.RCC_CR_HSIRDY) == 0 {
 	}
 
 	stm32.RCC.CFGR |= stm32.RCC_CFGR_PLLSRC   // set PLL source to HSE

--- a/targets/bluepill.json
+++ b/targets/bluepill.json
@@ -12,5 +12,7 @@
 	"extra-files": [
 		"src/device/stm32/stm32f103xx.s"
 	],
-	"flash": "openocd -f interface/stlink-v2.cfg -f target/stm32f1x.cfg -c 'program {hex} reset exit'"
+	"flash": "openocd -f interface/stlink-v2.cfg -f target/stm32f1x.cfg -c 'program {hex} reset exit'",
+	"ocd-daemon": ["openocd", "-f", "interface/stlink-v2.cfg", "-f", "target/stm32f1x.cfg"],
+	"gdb-initial-cmds": ["target remote :3333", "monitor halt", "load", "monitor reset", "c"]
 }


### PR DESCRIPTION
This PR adds support for i2c to the stm32f103xx boards such as the "Bluepill".

In similar fashion to the UART and SPI interfaces, the stm32 starts numbering with `I2C1`, hence `I2C0` and `I2C1` both refer to the first interface. Support for the actual second interface `I2C2` will have to await a future PR. 