### PR TITLE
compiler: add GOOS and GOARCH as default tags

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -98,9 +98,7 @@ func NewCompiler(pkgName string, config Config) (*Compiler, error) {
 	if config.Triple == "" {
 		config.Triple = llvm.DefaultTargetTriple()
 	}
-	if len(config.BuildTags) == 0 {
-		config.BuildTags = []string{config.GOOS, config.GOARCH}
-	}
+	config.BuildTags = append(config.BuildTags, config.GOOS, config.GOARCH)
 	c := &Compiler{
 		Config:  config,
 		difiles: make(map[string]llvm.Metadata),

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -402,6 +403,8 @@ func Run(pkgName string) error {
 	config := compiler.Config{
 		RootDir:    sourceDir(),
 		GOPATH:     getGopath(),
+		GOARCH:     runtime.GOARCH,
+		GOOS:       runtime.GOOS,
 		InitInterp: true,
 	}
 	c, err := compiler.NewCompiler(pkgName, config)

--- a/target.go
+++ b/target.go
@@ -204,16 +204,15 @@ func defaultTarget(goos, goarch, triple string) (*TargetSpec, error) {
 	// No target spec available. Use the default one, useful on most systems
 	// with a regular OS.
 	spec := TargetSpec{
-		Triple:    triple,
-		GOOS:      goos,
-		GOARCH:    goarch,
-		BuildTags: []string{goos, goarch},
-		Compiler:  commands["clang"],
-		Linker:    "cc",
-		LDFlags:   []string{"-no-pie"}, // WARNING: clang < 5.0 requires -nopie
-		Objcopy:   "objcopy",
-		GDB:       "gdb",
-		GDBCmds:   []string{"run"},
+		Triple:   triple,
+		GOOS:     goos,
+		GOARCH:   goarch,
+		Compiler: commands["clang"],
+		Linker:   "cc",
+		LDFlags:  []string{"-no-pie"}, // WARNING: clang < 5.0 requires -nopie
+		Objcopy:  "objcopy",
+		GDB:      "gdb",
+		GDBCmds:  []string{"run"},
 	}
 	if goarch != runtime.GOARCH {
 		// Some educated guesses as to how to invoke helper programs.


### PR DESCRIPTION
With master branch, I got this error on Linux.
```
error: compiler: could not compile: src/runtime/gc_dumb.go:14:15: undeclared name: heapStart
```
The PR fixes this.