### PR TITLE
bugfix: SVD wrapper generator needs to handle case with nested registers that have same address

### DIFF
--- a/tools/gen-device-svd.py
+++ b/tools/gen-device-svd.py
@@ -370,7 +370,9 @@ const (
                             regType += '\t\t_padding{padNumber} {subregType}\n'.format(padNumber=padNumber, subregType='RegValue16')
                         else:
                             numSkip = (subregister['address'] - subaddress)
-                            if numSkip == 1:
+                            if numSkip < 1:
+                                continue
+                            elif numSkip == 1:
                                 regType += '\t\t_padding{padNumber} {subregType}\n'.format(padNumber=padNumber, subregType='RegValue8')
                             else:
                                 regType += '\t\t_padding{padNumber} [{num}]{subregType}\n'.format(padNumber=padNumber, num=numSkip, subregType='RegValue8')


### PR DESCRIPTION
This PR adds code to the SVD generator that can handle the case when nested registers have the same address to avoid duplicates and resulting incorrect negative padding.

So far, this is only needed to handle generation based on the ATSAMD21 SVD files.