### PR TITLE
Fix typo in wasm_exec.js preventing memory import

### DIFF
--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -322,7 +322,7 @@
 				true,
 				false,
 				global,
-				this._inst.exports.mem,
+				this._inst.exports.memory,
 				this,
 			];
 			this._refs = new Map();


### PR DESCRIPTION
Seems to have been left over from the original copy. This correction
should fix calls to the "memory" variable in syscall/js.