### PR TITLE
machine/atsamd21: improve GPIO config

### DIFF
--- a/src/machine/machine_atsamd21g18.go
+++ b/src/machine/machine_atsamd21g18.go
@@ -1,6 +1,6 @@
 // +build sam,atsamd21g18a
 
-// Peripheral abstraction layer for the atsamd21g18.
+// Peripheral abstraction layer for the atsamd21.
 //
 // Datasheet:
 // http://ww1.microchip.com/downloads/en/DeviceDoc/SAMD21-Family-DataSheet-DS40001882D.pdf
@@ -16,16 +16,45 @@ const CPU_FREQUENCY = 48000000
 type GPIOMode uint8
 
 const (
-	GPIO_INPUT  = 0
-	GPIO_OUTPUT = 1
+	GPIO_ANALOG       = 1
+	GPIO_SERCOM       = 2
+	GPIO_SERCOM_ALT   = 3
+	GPIO_TIMER        = 4
+	GPIO_TIMER_ALT    = 5
+	GPIO_COM          = 6
+	GPIO_AC_CLK       = 7
+	GPIO_DIGITAL      = 8
+	GPIO_INPUT        = 9
+	GPIO_INPUT_PULLUP = 10
+	GPIO_OUTPUT       = 11
+	GPIO_PWM          = GPIO_TIMER
+	GPIO_PWM_ALT      = GPIO_TIMER_ALT
 )
 
 // Configure this pin with the given configuration.
 func (p GPIO) Configure(config GPIOConfig) {
-	if config.Mode == GPIO_OUTPUT { // set output bit
+	switch config.Mode {
+	case GPIO_OUTPUT:
 		sam.PORT.DIRSET0 = (1 << p.Pin)
-	} else {
+		// output is also set to input enable so pin can read back its own value
+		p.setPinCfg(sam.PORT_PINCFG0_INEN)
+
+	case GPIO_INPUT:
 		sam.PORT.DIRCLR0 = (1 << p.Pin)
+		p.setPinCfg(sam.PORT_PINCFG0_INEN)
+
+	case GPIO_SERCOM:
+		if p.Pin&1 > 0 {
+			// odd pin, so save the even pins
+			val := p.getPMux() & sam.PORT_PMUX0_PMUXE_Msk
+			p.setPMux(val | (GPIO_SERCOM << sam.PORT_PMUX0_PMUXO_Pos))
+		} else {
+			// even pin, so save the odd pins
+			val := p.getPMux() & sam.PORT_PMUX0_PMUXO_Msk
+			p.setPMux(val | (GPIO_SERCOM << sam.PORT_PMUX0_PMUXE_Pos))
+		}
+		// enable port config
+		p.setPinCfg(sam.PORT_PINCFG0_PMUXEN | sam.PORT_PINCFG0_DRVSTR)
 	}
 }
 
@@ -41,5 +70,227 @@ func (p GPIO) Set(high bool) {
 		sam.PORT.OUTSET0 = (1 << p.Pin)
 	} else {
 		sam.PORT.OUTCLR0 = (1 << p.Pin)
+	}
+}
+
+// getPMux returns the value for the correct PMUX register for this pin.
+func (p GPIO) getPMux() sam.RegValue8 {
+	pin := p.Pin >> 1
+	switch pin {
+	case 0:
+		return sam.PORT.PMUX0_0
+	case 1:
+		return sam.PORT.PMUX0_1
+	case 2:
+		return sam.PORT.PMUX0_2
+	case 3:
+		return sam.PORT.PMUX0_3
+	case 4:
+		return sam.PORT.PMUX0_4
+	case 5:
+		return sam.PORT.PMUX0_5
+	case 6:
+		return sam.PORT.PMUX0_6
+	case 7:
+		return sam.PORT.PMUX0_7
+	case 8:
+		return sam.PORT.PMUX0_8
+	case 9:
+		return sam.PORT.PMUX0_9
+	case 10:
+		return sam.PORT.PMUX0_10
+	case 11:
+		return sam.PORT.PMUX0_11
+	case 12:
+		return sam.PORT.PMUX0_12
+	case 13:
+		return sam.PORT.PMUX0_13
+	case 14:
+		return sam.PORT.PMUX0_14
+	case 15:
+		return sam.PORT.PMUX0_15
+	default:
+		return 0
+	}
+}
+
+// setPMux sets the value for the correct PMUX register for this pin.
+func (p GPIO) setPMux(val sam.RegValue8) {
+	pin := p.Pin >> 1
+	switch pin {
+	case 0:
+		sam.PORT.PMUX0_0 = val
+	case 1:
+		sam.PORT.PMUX0_1 = val
+	case 2:
+		sam.PORT.PMUX0_2 = val
+	case 3:
+		sam.PORT.PMUX0_3 = val
+	case 4:
+		sam.PORT.PMUX0_4 = val
+	case 5:
+		sam.PORT.PMUX0_5 = val
+	case 6:
+		sam.PORT.PMUX0_6 = val
+	case 7:
+		sam.PORT.PMUX0_7 = val
+	case 8:
+		sam.PORT.PMUX0_8 = val
+	case 9:
+		sam.PORT.PMUX0_9 = val
+	case 10:
+		sam.PORT.PMUX0_10 = val
+	case 11:
+		sam.PORT.PMUX0_11 = val
+	case 12:
+		sam.PORT.PMUX0_12 = val
+	case 13:
+		sam.PORT.PMUX0_13 = val
+	case 14:
+		sam.PORT.PMUX0_14 = val
+	case 15:
+		sam.PORT.PMUX0_15 = val
+	}
+}
+
+// getPinCfg returns the value for the correct PINCFG register for this pin.
+func (p GPIO) getPinCfg() sam.RegValue8 {
+	switch p.Pin {
+	case 0:
+		return sam.PORT.PINCFG0_0
+	case 1:
+		return sam.PORT.PINCFG0_1
+	case 2:
+		return sam.PORT.PINCFG0_2
+	case 3:
+		return sam.PORT.PINCFG0_3
+	case 4:
+		return sam.PORT.PINCFG0_4
+	case 5:
+		return sam.PORT.PINCFG0_5
+	case 6:
+		return sam.PORT.PINCFG0_6
+	case 7:
+		return sam.PORT.PINCFG0_7
+	case 8:
+		return sam.PORT.PINCFG0_8
+	case 9:
+		return sam.PORT.PINCFG0_9
+	case 10:
+		return sam.PORT.PINCFG0_10
+	case 11:
+		return sam.PORT.PINCFG0_11
+	case 12:
+		return sam.PORT.PINCFG0_12
+	case 13:
+		return sam.PORT.PINCFG0_13
+	case 14:
+		return sam.PORT.PINCFG0_14
+	case 15:
+		return sam.PORT.PINCFG0_15
+	case 16:
+		return sam.PORT.PINCFG0_16
+	case 17:
+		return sam.PORT.PINCFG0_17
+	case 18:
+		return sam.PORT.PINCFG0_18
+	case 19:
+		return sam.PORT.PINCFG0_19
+	case 20:
+		return sam.PORT.PINCFG0_20
+	case 21:
+		return sam.PORT.PINCFG0_21
+	case 22:
+		return sam.PORT.PINCFG0_22
+	case 23:
+		return sam.PORT.PINCFG0_23
+	case 24:
+		return sam.PORT.PINCFG0_24
+	case 25:
+		return sam.PORT.PINCFG0_25
+	case 26:
+		return sam.PORT.PINCFG0_26
+	case 27:
+		return sam.PORT.PINCFG0_27
+	case 28:
+		return sam.PORT.PINCFG0_28
+	case 29:
+		return sam.PORT.PINCFG0_29
+	case 30:
+		return sam.PORT.PINCFG0_30
+	case 31:
+		return sam.PORT.PINCFG0_31
+	default:
+		return 0
+	}
+}
+
+// setPinCfg sets the value for the correct PINCFG register for this pin.
+func (p GPIO) setPinCfg(val sam.RegValue8) {
+	switch p.Pin {
+	case 0:
+		sam.PORT.PINCFG0_0 = val
+	case 1:
+		sam.PORT.PINCFG0_1 = val
+	case 2:
+		sam.PORT.PINCFG0_2 = val
+	case 3:
+		sam.PORT.PINCFG0_3 = val
+	case 4:
+		sam.PORT.PINCFG0_4 = val
+	case 5:
+		sam.PORT.PINCFG0_5 = val
+	case 6:
+		sam.PORT.PINCFG0_6 = val
+	case 7:
+		sam.PORT.PINCFG0_7 = val
+	case 8:
+		sam.PORT.PINCFG0_8 = val
+	case 9:
+		sam.PORT.PINCFG0_9 = val
+	case 10:
+		sam.PORT.PINCFG0_10 = val
+	case 11:
+		sam.PORT.PINCFG0_11 = val
+	case 12:
+		sam.PORT.PINCFG0_12 = val
+	case 13:
+		sam.PORT.PINCFG0_13 = val
+	case 14:
+		sam.PORT.PINCFG0_14 = val
+	case 15:
+		sam.PORT.PINCFG0_15 = val
+	case 16:
+		sam.PORT.PINCFG0_16 = val
+	case 17:
+		sam.PORT.PINCFG0_17 = val
+	case 18:
+		sam.PORT.PINCFG0_18 = val
+	case 19:
+		sam.PORT.PINCFG0_19 = val
+	case 20:
+		sam.PORT.PINCFG0_20 = val
+	case 21:
+		sam.PORT.PINCFG0_21 = val
+	case 22:
+		sam.PORT.PINCFG0_22 = val
+	case 23:
+		sam.PORT.PINCFG0_23 = val
+	case 24:
+		sam.PORT.PINCFG0_24 = val
+	case 25:
+		sam.PORT.PINCFG0_25 = val
+	case 26:
+		sam.PORT.PINCFG0_26 = val
+	case 27:
+		sam.PORT.PINCFG0_27 = val
+	case 28:
+		sam.PORT.PINCFG0_28 = val
+	case 29:
+		sam.PORT.PINCFG0_29 = val
+	case 30:
+		sam.PORT.PINCFG0_30 = val
+	case 31:
+		sam.PORT.PINCFG0_31 = val
 	}
 }

--- a/src/runtime/runtime_atsamd21g18.go
+++ b/src/runtime/runtime_atsamd21g18.go
@@ -187,24 +187,24 @@ func initRTC() {
 	sam.PM.APBAMASK |= sam.PM_APBAMASK_RTC_
 
 	// disable RTC
-	sam.RTC.MODE0.CTRL = 0
+	sam.RTC_MODE0.CTRL = 0
 	waitForSync()
 
 	// reset RTC
-	sam.RTC.MODE0.CTRL |= sam.RTC_MODE0_CTRL_SWRST
+	sam.RTC_MODE0.CTRL |= sam.RTC_MODE0_CTRL_SWRST
 	waitForSync()
 
 	// set Mode0 to 32-bit counter (mode 0) with prescaler 1 and GCLK2 is 32KHz/1
-	sam.RTC.MODE0.CTRL = sam.RegValue16((sam.RTC_MODE0_CTRL_MODE_COUNT32 << sam.RTC_MODE0_CTRL_MODE_Pos) |
+	sam.RTC_MODE0.CTRL = sam.RegValue16((sam.RTC_MODE0_CTRL_MODE_COUNT32 << sam.RTC_MODE0_CTRL_MODE_Pos) |
 		(sam.RTC_MODE0_CTRL_PRESCALER_DIV1 << sam.RTC_MODE0_CTRL_PRESCALER_Pos) |
 		sam.RTC_MODE0_CTRL_MATCHCLR)
 	waitForSync()
 
-	sam.RTC.MODE0.COMP0 = 0xffffffff
+	sam.RTC_MODE0.COMP0 = 0xffffffff
 	waitForSync()
 
 	// re-enable RTC
-	sam.RTC.MODE0.CTRL |= sam.RTC_MODE0_CTRL_ENABLE
+	sam.RTC_MODE0.CTRL |= sam.RTC_MODE0_CTRL_ENABLE
 	waitForSync()
 
 	arm.EnableIRQ(sam.IRQ_RTC)
@@ -241,10 +241,10 @@ func sleepTicks(d timeUnit) {
 // ticks returns number of microseconds since start.
 func ticks() timeUnit {
 	// request read of count
-	sam.RTC.MODE0.READREQ = sam.RTC_MODE0_READREQ_RREQ
+	sam.RTC_MODE0.READREQ = sam.RTC_MODE0_READREQ_RREQ
 	waitForSync()
 
-	rtcCounter := uint64(sam.RTC.MODE0.COUNT) * 30 // each counter tick == 30.5us
+	rtcCounter := uint64(sam.RTC_MODE0.COUNT) * 30 // each counter tick == 30.5us
 	offset := (rtcCounter - timerLastCounter)      // change since last measurement
 	timerLastCounter = rtcCounter
 	timestamp += timeUnit(offset) // TODO: not precise
@@ -260,16 +260,16 @@ func timerSleep(ticks uint32) {
 	}
 
 	// request read of count
-	sam.RTC.MODE0.READREQ = sam.RTC_MODE0_READREQ_RREQ
+	sam.RTC_MODE0.READREQ = sam.RTC_MODE0_READREQ_RREQ
 	waitForSync()
 
 	// set compare value
-	cnt := sam.RTC.MODE0.COUNT
-	sam.RTC.MODE0.COMP0 = sam.RegValue(uint32(cnt) + (ticks / 30)) // each counter tick == 30.5us
+	cnt := sam.RTC_MODE0.COUNT
+	sam.RTC_MODE0.COMP0 = sam.RegValue(uint32(cnt) + (ticks / 30)) // each counter tick == 30.5us
 	waitForSync()
 
 	// enable IRQ for CMP0 compare
-	sam.RTC.MODE0.INTENSET |= sam.RTC_MODE0_INTENSET_CMP0
+	sam.RTC_MODE0.INTENSET |= sam.RTC_MODE0_INTENSET_CMP0
 
 	for !timerWakeup {
 		arm.Asm("wfi")
@@ -279,7 +279,7 @@ func timerSleep(ticks uint32) {
 //go:export RTC_IRQHandler
 func handleRTC() {
 	// disable IRQ for CMP0 compare
-	sam.RTC.MODE0.INTFLAG = sam.RTC_MODE0_INTENSET_CMP0
+	sam.RTC_MODE0.INTFLAG = sam.RTC_MODE0_INTENSET_CMP0
 
 	timerWakeup = true
 }

--- a/tools/gen-device-svd.py
+++ b/tools/gen-device-svd.py
@@ -81,15 +81,15 @@ def readSVD(path, sourceURL):
             }
             device.peripherals.append(peripheral)
             peripheralDict[name] = peripheral
-            # TODO: handle peripheral "shadows" here.
-            for subtype in derivedFrom['subtypes']:
-                subp = {
-                    'name':        name + "_"+subtype['clusterName'],
-                    'groupName':   subtype['groupName'],
-                    'description': subtype['description'],
-                    'baseAddress': baseAddress,
-                }
-                device.peripherals.append(subp)
+            if 'subtypes' in derivedFrom:
+                for subtype in derivedFrom['subtypes']:
+                    subp = {
+                        'name':        name + "_"+subtype['clusterName'],
+                        'groupName':   subtype['groupName'],
+                        'description': subtype['description'],
+                        'baseAddress': baseAddress,
+                    }
+                    device.peripherals.append(subp)
             continue
 
         peripheral = {


### PR DESCRIPTION
This PR improves the GPIO config for the SAMD21 family of devices to support the entire range of PORTA pins, as well as correctly handling configuration for input, output, and the upcoming `SERCOMx` features such as UART and I2C.

Once the generator corrections PR has been merged, this PR only requires commit d763e21