### PR TITLE
Better error message on import cycles

### DIFF
--- a/loader/errors.go
+++ b/loader/errors.go
@@ -1,5 +1,10 @@
 package loader
 
+import (
+	"go/token"
+	"strings"
+)
+
 // Errors contains a list of parser errors or a list of typechecker errors for
 // the given package.
 type Errors struct {
@@ -15,13 +20,20 @@ func (e Errors) Error() string {
 // packages is a list from the root package to the leaf package that imports one
 // of the packages in the list.
 type ImportCycleError struct {
-	Packages []string
+	Packages        []string
+	ImportPositions []token.Position
 }
 
 func (e *ImportCycleError) Error() string {
-	msg := "import cycle: " + e.Packages[0]
-	for _, path := range e.Packages[1:] {
-		msg += " → " + path
+	var msg strings.Builder
+	msg.WriteString("import cycle:\n\t")
+	msg.WriteString(strings.Join(e.Packages, "\n\t"))
+	msg.WriteString("\n at ")
+	for i, pos := range e.ImportPositions {
+		if i > 0 {
+			msg.WriteString(", ")
+		}
+		msg.WriteString(pos.String())
 	}
-	return msg
+	return msg.String()
 }


### PR DESCRIPTION
Better readability, points to an offending code position, correctly displays the import chain when a package automatically imports its subpackages.