### PR TITLE
runtime/strings: add implementation of strings.IndexByte()

### DIFF
--- a/src/runtime/string.go
+++ b/src/runtime/string.go
@@ -166,3 +166,14 @@ func decodeUTF8(s string, index uintptr) (rune, uintptr) {
 		return 0xfffd, 1
 	}
 }
+
+// indexByte returns the index of the first instance of c in s, or -1 if c is not present in s.
+//go:linkname indexByte strings.IndexByte
+func indexByte(s string, c byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
This PR adds implementation of `strings.IndexByte()` which resolves #154 